### PR TITLE
Added examples for 1and1, MailMarchal, BigFoot and MessageLabs

### DIFF
--- a/eg/maildir-as-a-sample/new/1and1.eml
+++ b/eg/maildir-as-a-sample/new/1and1.eml
@@ -1,0 +1,38 @@
+From: "Mail Delivery System" <mailer-daemon@kundenserver.de>
+To: user1@xxxxxxxxxxxxxxxxxxx.pt
+Date: Tue, 23 Dec 2014 21:39:30 +0100
+Subject: Mail delivery failed: returning message to sender
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+X-UI-Out-Filterresults: unknown:0;
+
+This message was created automatically by mail delivery software.
+
+A message that you sent could not be delivered to one or more of
+its recipients. This is a permanent error.
+
+The following address failed:
+
+general@example.eu
+
+For the following reason:
+
+Mail size limit exceeded. For explanation visit
+http://postmaster.1and1.com/en/error-messages?ip=%1s
+
+--- The header of the original message is following. ---
+
+Received: (qmail 22456 invoked from network); 23 Dec 2014 20:39:27 -0000
+Received: from unknown (HELO php09) (10.11.12.13)
+  by relay.local with SMTP; 23 Dec 2014 20:39:27 -0000
+Date: Tue, 23 Dec 2014 20:39:24 +0000
+Message-ID: <2014122.Horde.aVib3NKNmpMSMBPv_KPp-w9@mail.xxxxxxxxxxxxxxxxxxx.pt>
+From: user1@xxxxxxxxxxxxxxxxxxx.pt
+To: Joaquim <general@example.eu>
+Subject: BOAS FESTAS!
+In-Reply-To: <CAA5-N8cB+mrTuqRQbqPrrSVApLorXtyeVqV3tw1=DgMFUsQ@mail.gmail.com>
+Content-Type: multipart/alternative; boundary="=_Bj5UaGbJV86-J0NyTypbMg8"
+MIME-Version: 1.0
+
+

--- a/eg/maildir-as-a-sample/new/MailMarshal.eml
+++ b/eg/maildir-as-a-sample/new/MailMarshal.eml
@@ -1,0 +1,43 @@
+Received: from MailMarshal.Sender ([127.0.0.1]) by relay.xxxxxxxxx.com
+	id <C549996730000>; Mon, 22 Dec 2014 16:21:07 +0000
+Message-ID: <C549996730000@relay.xxxxxxxxxxxx.com>
+From: postmaster@igfej.xxxxxxxxxxxx.com
+To: originalsender@example.com
+CC: 
+Date: Mon, 22 Dec 2014 16:21:07 +0000
+Subject: Undeliverable Mail: "IIdentificação"
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="--=30ecf893-1096-4eca-ba85-bc3fca72024d"
+
+
+----=30ecf893-1096-4eca-ba85-bc3fca72024d
+Content-Type: text/plain;
+	charset="iso-8859-1"
+Content-Transfer-Encoding: 7bit
+
+Your message:
+   From:    originalsender@example.com
+   Subject: IIdentificação
+
+Could not be delivered because of
+
+550 5.1.1 User unknown
+
+The following recipients were affected: 
+    dummyuser@blabla.xxxxxxxxxxxx.com
+
+
+
+
+Additional Information
+======================
+Original Sender:    <originalsender@example.com>
+Sender-MTA:         <10.11.12.13>
+Remote-MTA:			<10.0.0.1>
+Reporting-MTA:      <relay.xxxxxxxxxxxx.com>
+MessageName:        <B549996730000.000000000001.0003.mml>
+Last-Attempt-Date:  <16:21:07 seg, 22 Dezembro 2014>
+
+----=30ecf893-1096-4eca-ba85-bc3fca72024d--
+

--- a/eg/maildir-as-a-sample/new/bigfoot.eml
+++ b/eg/maildir-as-a-sample/new/bigfoot.eml
@@ -1,0 +1,64 @@
+Received: by LITEMAIL51.bigfoot.com (LiteMail v3.03(LITEMAIL51)) with SMTP id 1412281813_LITEMAIL51_5437911_7120404;
+	Sun, 28 Dec 2014 18:17:18 -0800 
+Date: Sun, 28 Dec 2014 18:17:16 -0800
+From: Mail Delivery Subsystem <MAILER-DAEMON@bigfoot.com>
+Message-Id: <14122813_LITEMAIL57_491202_776323_1704@LITEMAIL57.bigfoot.com>
+To: <user@xxxxxxxxxx.com>
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="201412281816847"
+Subject: Returned mail: Requested action not taken: mailbox name not allowed
+Auto-Submitted: auto-generated (failure)
+
+This is a MIME-encapsulated message
+
+--201412281816847
+
+The original message was received at Sun, 28 Dec 2014 18:17:16 -0800
+from LITEMAIL57.bigfoot.com [192.168.12.53]
+
+
+
+   ----- The following addresses had permanent fatal errors -----
+<destinaion@example.net>
+
+   ----- Transcript of session follows -----
+>>> RCPT TO:<destinaion@example.net>
+<<< 553 Invalid recipient destinaion@example.net (Mode: normal)
+
+--201412281816847
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; litemail57.bigfoot.com
+Arrival-Date: Sun, 28 Dec 2014 18:17:16 -0800
+
+Final-Recipient: RFC822; <destinaion@example.net>
+Action: failed
+Status: 5.7.1
+Remote-MTA: DNS; p01c11m075.mx.example.net
+Diagnostic-Code: SMTP; 553 Invalid recipient destinaion@example.net (Mode: normal)
+Last-Attempt-Date: Sun, 28 Dec 2014 18:17:16 -0800
+
+
+
+--201412281816847
+Content-Type: message/partial
+
+Received: by LITEMAIL57.bigfoot.com (LiteMail v3.03(LITEMAIL57)) with SMTP id 1412281811_LITEMAIL57_4742901_15695198;
+	Sun, 28 Dec 2014 18:17:14 -0800 
+Received: from xxxxxxxxxx.com ([172.16.17.18]) 
+	by litemail16.bigfoot.net with SMTP id 1419818724.17508;
+	Sun, 28 Dec 2014 21:05:25 -0500
+Received: from unknown (HELO horde01) (10.1.12.13)
+  by relay3 with SMTP; 29 Dec 2014 02:17:06 -0000
+Cc: recipient list not shown: ;
+Date: Mon, 29 Dec 2014 02:17:05 +0000
+Message-ID: <20141229021705.Horde.ht6XOg3pMXT2XD9vNBMt1A6@mail.xxxxxxxxxx.com>
+From: user@xxxxxxxxxx.com
+Subject: Thank you.
+Content-Type: text/plain; charset=UTF-8; format=flowed; DelSp=Yes
+MIME-Version: 1.0
+Content-Disposition: inline
+
+--201412281816847--
+

--- a/eg/maildir-as-a-sample/new/messagelabs.eml
+++ b/eg/maildir-as-a-sample/new/messagelabs.eml
@@ -1,0 +1,76 @@
+Received: from [85.158.137.35] by server-17.bemta-3.messagelabs.com id A1/BA-11608-703D9945; Tue, 23 Dec 2014 20:39:35 +0000
+X-Msg-Ref: server-11.tower-143.messagelabs.com!1419367175!36473369!1
+X-Originating-IP: [10.245.230.38]
+X-StarScan-Received:
+X-StarScan-Version: 6.12.5; banners=-,-,-
+X-VirusChecked: Checked
+Received: (qmail 21907 invoked from network); 23 Dec 2014 20:39:35 -0000
+Received: from mail5.bemta3.messagelabs.com (HELO mail5.bemta3.messagelabs.com) (10.245.230.38)
+  by server-11.tower-143.messagelabs.com with DHE-RSA-AES256-SHA encrypted SMTP; 23 Dec 2014 20:39:35 -0000
+Received: by server-15.bemta-3.messagelabs.com id 5E/3F-17735-703D9945; Tue, 23 Dec 2014 20:39:35 +0000
+From: Mail Delivery System <MAILER-DAEMON@messagelabs.com>
+To: <user@xxxxxxxxxxxxxx.com>
+Subject: Mail Delivery Failure
+Date: Tue, 23 Dec 2014 20:39:35 +0000
+Content-Type: multipart/report; report-type=delivery-status;
+  boundary="b0Nvs+XKfKLLRaP/Qo8jZhQPoiqeWi3KWPXMgw=="
+
+--b0Nvs+XKfKLLRaP/Qo8jZhQPoiqeWi3KWPXMgw==
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+This is the mail delivery agent at messagelabs.com.
+
+I was unable to deliver your message to the following addresses:
+
+maria@dest.example.net
+
+Reason: 550 maria@dest.example.net... No such user
+
+The message subject was: Re: BOAS FESTAS!
+The message date was: Tue, 23 Dec 2014 20:39:24 +0000
+The message identifier was: DB/3F-17375-60D39495
+The message reference was: server-5.tower-143.messagelabs.com!1419367172!32=
+691968!1
+
+Please do not reply to this email as it is sent from an unattended mailbox.
+Please visit www.messagelabs.com/support for more details
+about this error message and instructions to resolve this issue.
+
+
+--b0Nvs+XKfKLLRaP/Qo8jZhQPoiqeWi3KWPXMgw==
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; server-15.bemta-3.messagelabs.com
+Arrival-Date: Tue, 23 Dec 2014 20:39:34 +0000
+
+Action: failed
+Status: 5.0.0
+Last-Attempt-Date: Tue, 23 Dec 2014 20:39:35 +0000
+Remote-MTA: dns; mail.dest.example.net
+Diagnostic-Code: smtp; 550 maria@dest.example.net... No such user
+Final-Recipient: rfc822; maria@dest.example.net
+
+--b0Nvs+XKfKLLRaP/Qo8jZhQPoiqeWi3KWPXMgw==
+Content-Type: text/rfc822-headers
+
+Return-Path: <user@xxxxxxxxxxxxxx.com>
+Received: from [85.158.137.35] by server-15.bemta-3.messagelabs.com id DB/3F-17735-603D9945; Tue, 23 Dec 2014 20:39:34 +0000
+X-Env-Sender: user@xxxxxxxxxxxxxx.com
+X-Msg-Ref: server-5.tower-143.messagelabs.com!1419367172!32961698!1
+X-SpamReason: No, hits=0.0 required=7.0 tests=sa_preprocessor: 
+  VHJ1c3RlZCBJUDogMjEyLjU1LjE1NC4yNCA9PiA4NjcxNw==\n
+X-StarScan-Received:
+X-StarScan-Version: 6.12.5; banners=-,-,-
+X-VirusChecked: Checked
+Date: Tue, 23 Dec 2014 20:39:24 +0000
+Message-ID: <20141223203924.Horde.aVib3NKNmpMSMBPv_KPp-w9@mail.xxxxxxxxxxxxxx.com>
+From: user@xxxxxxxxxxxxxx.com
+To: Joaquim Carreira <manuel@example.com>
+Subject: Re: BOAS FESTAS!
+Content-Type: multipart/alternative; boundary="=_Bj5UaGbJV86-J0NyTypbMg8"
+MIME-Version: 1.0
+
+
+--b0Nvs+XKfKLLRaP/Qo8jZhQPoiqeWi3KWPXMgw==--
+


### PR DESCRIPTION
Added 4 examples.
1and1 ( big german provider ) and MailMarchal ( security vendor ) are not detected.

Bigfoot and MessageLabs are detected as generic RFC3464 but uploaded because they are relevant. 
