### PR TITLE
Improvement of redundant codes in each MTA/MSP module

### DIFF
--- a/lib/Sisimai/Data.pm
+++ b/lib/Sisimai/Data.pm
@@ -85,7 +85,7 @@ sub new {
     return undef unless ref $thing->{'recipient'} eq 'Sisimai::Address';
     return undef unless ref $thing->{'addresser'} eq 'Sisimai::Address';
 
-    $thing->{'token'} = Sisimai::String->token( 
+    $thing->{'token'} = Sisimai::String->token(
                             $thing->{'addresser'}->address,
                             $thing->{'recipient'}->address,
                             $argvs->{'timestamp'} );

--- a/lib/Sisimai/MSP/DE/EinsUndEins.pm
+++ b/lib/Sisimai/MSP/DE/EinsUndEins.pm
@@ -14,14 +14,10 @@ my $Re1 = {
     'rfc822'  => qr/\A--- The header of the original message is following/,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'mesgtoobig' => qr/Mail[ ]size[ ]limit[ ]exceeded/x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { '1&1: http://www.1and1.de' }
 sub smtpagent   { 'DE::EinsUndEins' }
@@ -52,9 +48,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -79,26 +75,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -165,7 +147,8 @@ sub scan {
         $e->{'spec'}   = 'SMTP';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/DE/GMX.pm
+++ b/lib/Sisimai/MSP/DE/GMX.pm
@@ -13,14 +13,10 @@ my $Re1 = {
     'rfc822'  => qr/\A--- The header of the original message is following/,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'expired' => qr/delivery[ ]retry[ ]timeout[ ]exceeded/x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'GMX: http://www.gmx.net' }
 sub smtpagent   { 'DE::GMX' }
@@ -53,9 +49,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -80,26 +76,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -190,7 +173,8 @@ sub scan {
         $e->{'spec'}   = 'SMTP';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/JP/Biglobe.pm
+++ b/lib/Sisimai/MSP/JP/Biglobe.pm
@@ -14,15 +14,11 @@ my $Re1 = {
     'rfc822' => qr|\AContent-Type: message/rfc822\z|,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'filtered'    => qr/Mail Delivery Failed[.]+ User unknown/,
     'mailboxfull' => qr/The number of messages in recipient's mailbox exceeded the local limit[.]/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'BIGLOBE: http://www.biglobe.ne.jp' }
 sub smtpagent   { 'JP::Biglobe' }
@@ -51,9 +47,9 @@ sub scan {
     require Sisimai::Address;
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -78,26 +74,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -167,7 +150,8 @@ sub scan {
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/JP/EZweb.pm
+++ b/lib/Sisimai/MSP/JP/EZweb.pm
@@ -22,7 +22,6 @@ my $Re1 = {
     'boundary' => qr/\A__SISIMAI_PSEUDO_BOUNDARY__\z/,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     #'notaccept' => [ qr/The following recipients did not receive this message:/ ],
     'mailboxfull' => [
@@ -43,10 +42,7 @@ my $ReFailure = {
         qr/Each of the following recipients was rejected by a remote mail server/,
     ],
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'au EZweb: http://www.au.kddi.com/mobile/' }
 sub smtpagent   { 'JP::EZweb' }
@@ -91,9 +87,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -127,26 +123,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -280,7 +263,8 @@ sub scan {
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/JP/KDDI.pm
+++ b/lib/Sisimai/MSP/JP/KDDI.pm
@@ -20,16 +20,12 @@ my $Re1 = {
     'error'  => qr/Could not be delivered to:? /,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'mailboxfull' => qr/As[ ]their[ ]mailbox[ ]is[ ]full/x,
     'norelaying'  => qr/Due[ ]to[ ]the[ ]following[ ]SMTP[ ]relay[ ]error/x,
     'hostunknown' => qr/As[ ]the[ ]remote[ ]domain[ ]doesnt[ ]exist/x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'au by KDDI: http://www.au.kddi.com' }
 sub smtpagent   { 'JP::KDDI' }
@@ -63,9 +59,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -90,26 +86,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -182,7 +165,8 @@ sub scan {
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/RU/MailRu.pm
+++ b/lib/Sisimai/MSP/RU/MailRu.pm
@@ -24,12 +24,10 @@ my $Re1 = {
     'begin'  => qr/\AThis message was created automatically by mail delivery software[.]/,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReCommand = [
     qr/SMTP error from remote (?:mail server|mailer) after ([A-Za-z]{4})/,
     qr/SMTP error from remote (?:mail server|mailer) after end of ([A-Za-z]{4})/,
 ];
-
 my $ReFailure = {
     'expired' => qr{(?:
          retry[ ]timeout[ ]exceeded
@@ -66,10 +64,7 @@ my $ReFailure = {
         Too[ ]many[ ]["]Received["][ ]headers[ ]
     }x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { '@mail.ru: https://mail.ru' }
 sub smtpagent   { 'RU::MailRu' }
@@ -99,9 +94,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $localhost0 = '';    # (String) Local MTA
@@ -127,26 +122,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -294,7 +276,8 @@ sub scan {
         $e->{'command'} ||= '';
         $e->{'agent'}     = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/RU/Yandex.pm
+++ b/lib/Sisimai/MSP/RU/Yandex.pm
@@ -12,10 +12,7 @@ my $Re1 = {
     'rfc822' => qr|\AContent-Type: message/rfc822|,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Yandex.Mail: http://www.yandex.ru' }
 sub smtpagent   { 'RU::Yandex' }
@@ -52,9 +49,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my @commandset = ();    # (Array) ``in reply to * command'' list
@@ -87,26 +84,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -227,7 +211,8 @@ sub scan {
         $e->{'spec'} ||= 'SMTP';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/UK/MessageLabs.pm
+++ b/lib/Sisimai/MSP/UK/MessageLabs.pm
@@ -14,14 +14,10 @@ my $Re1 = {
     'rfc822'  => qr|\AContent-Type: text/rfc822-headers\z|,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'userunknown' => qr/No[ ]such[ ]user/x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Symantec.cloud http://www.messagelabs.com' }
 sub smtpagent   { 'UK::MessageLabs' }
@@ -57,9 +53,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connvalues = 0;     # (Integer) Flag, 1 if all the value of $connheader have been set
@@ -91,26 +87,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -235,7 +218,8 @@ sub scan {
             $e->{'status'} = $r if length $r;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/AmazonSES.pm
+++ b/lib/Sisimai/MSP/US/AmazonSES.pm
@@ -17,10 +17,7 @@ my $Re1 = {
 my $ReFailure = {
     'expired' => qr/Delivery[ ]expired/x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Amazon SES(Sending): http://aws.amazon.com/ses/' };
 sub smtpagent   { 'US::AmazonSES' }
@@ -52,9 +49,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connvalues = 0;     # (Integer) Flag, 1 if all the value of $connheader have been set
@@ -84,26 +81,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -234,7 +218,8 @@ sub scan {
         $e->{'spec'}   ||= 'SMTP';
         $e->{'agent'}    = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/AmazonWorkMail.pm
+++ b/lib/Sisimai/MSP/US/AmazonWorkMail.pm
@@ -15,10 +15,7 @@ my $Re1 = {
     'rfc822'  => qr|\Acontent-type: message/rfc822\z|,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Amazon WorkMail: https://aws.amazon.com/workmail/' }
 sub smtpagent   { 'US::AmazonWorkMail' }
@@ -68,9 +65,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connvalues = 0;     # (Integer) Flag, 1 if all the value of $connheader have been set
@@ -99,26 +96,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -212,7 +196,8 @@ sub scan {
         $e->{'spec'}   ||= 'SMTP';
         $e->{'agent'}    = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Aol.pm
+++ b/lib/Sisimai/MSP/US/Aol.pm
@@ -13,14 +13,10 @@ my $Re1 = {
     'rfc822'  => qr|\AContent-Type: message/rfc822|,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'hostunknown' => qr/Host[ ]or[ ]domain[ ]name[ ]not[ ]found/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Aol Mail: http://www.aol.com' }
 sub smtpagent   { 'US::Aol' }
@@ -59,9 +55,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connvalues = 0;     # (Integer) Flag, 1 if all the value of $connheader have been set
@@ -93,26 +89,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -222,7 +205,8 @@ sub scan {
         $e->{'spec'} ||= 'SMTP';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Bigfoot.pm
+++ b/lib/Sisimai/MSP/US/Bigfoot.pm
@@ -14,10 +14,7 @@ my $Re1 = {
     'rfc822' => qr|\AContent-Type: message/partial|,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Bigfoot: http://www.bigfoot.com' }
 sub smtpagent   { 'US::Bigfoot' }
@@ -47,9 +44,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
@@ -84,26 +81,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -224,7 +207,8 @@ sub scan {
         $e->{'spec'} ||= 'SMTP';
         $e->{'agent'} |= __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Facebook.pm
+++ b/lib/Sisimai/MSP/US/Facebook.pm
@@ -71,10 +71,7 @@ my $ReFailure = {
         'RCP-T4',   # The attempted recipient address is currently deactivated. The user may or may not reactivate it.
     ],
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Facebook: https://www.facebook.com' }
 sub smtpagent   { 'US::Facebook' }
@@ -102,9 +99,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $fbresponse = '';    # (String) Response code from Facebook
@@ -137,26 +134,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -288,7 +272,8 @@ sub scan {
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Office365.pm
+++ b/lib/Sisimai/MSP/US/Office365.pm
@@ -29,10 +29,7 @@ my $CodeTable = {
     '5.7.1'     => 'rejected',
     '5.7.133'   => 'rejected',
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Microsoft Office 365: http://office.microsoft.com/' }
 sub smtpagent   { 'US::Office365' }
@@ -99,9 +96,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connheader = {};
@@ -129,26 +126,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -259,7 +243,8 @@ sub scan {
             $e->{'reason'} = $CodeTable->{ $e->{'status'} } || ''
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Outlook.pm
+++ b/lib/Sisimai/MSP/US/Outlook.pm
@@ -15,15 +15,11 @@ my $Re1 = {
     'rfc822' => qr|\AContent-Type: message/rfc822\z|,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'hostunknown' => qr/The mail could not be delivered to the recipient because the domain is not reachable/,
     'userunknown' => qr/Requested action not taken: mailbox unavailable/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Microsoft Outlook.com: https://www.outlook.com/' }
 sub smtpagent   { 'US::Outlook' }
@@ -59,9 +55,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connvalues = 0;     # (Integer) Flag, 1 if all the value of $connheader have been set
@@ -93,26 +89,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -230,7 +213,8 @@ sub scan {
             $e->{'status'} = $r if length $r;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/ReceivingSES.pm
+++ b/lib/Sisimai/MSP/US/ReceivingSES.pm
@@ -14,7 +14,6 @@ my $Re1 = {
     'rfc822'  => qr|\Acontent-type: text/rfc822-headers\z|,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     # The followings are error messages in Rule sets/*/Actions/Template
     'filtered'      => qr/Mailbox does not exist/,
@@ -22,10 +21,7 @@ my $ReFailure = {
     'mailboxfull'   => qr/Mailbox full/,
     'contenterror'  => qr/Message content rejected/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Amazon SES(Receiving): http://aws.amazon.com/ses/' };
 sub smtpagent   { 'US::ReceivingSES' }
@@ -56,9 +52,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connvalues = 0;     # (Integer) Flag, 1 if all the value of $connheader have been set
@@ -90,26 +86,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -236,7 +219,8 @@ sub scan {
         $e->{'spec'}   ||= 'SMTP';
         $e->{'agent'}    = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/SendGrid.pm
+++ b/lib/Sisimai/MSP/US/SendGrid.pm
@@ -15,10 +15,7 @@ my $Re1 = {
     'rfc822' => qr|\AContent-Type: message/rfc822|,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'SendGrid: http://sendgrid.com/' }
 sub smtpagent   { 'US::SendGrid' }
@@ -52,9 +49,9 @@ sub scan {
     require Sisimai::DateTime;
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
@@ -86,26 +83,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -246,7 +230,8 @@ sub scan {
         $e->{'agent'}     = __PACKAGE__->smtpagent;
         $e->{'command'} ||= $commandtxt;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Yahoo.pm
+++ b/lib/Sisimai/MSP/US/Yahoo.pm
@@ -12,10 +12,7 @@ my $Re1 = {
     'rfc822'  => qr/\A--- Below this line is a copy of the message[.]\z/,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Yahoo! MAIL: https://www.yahoo.com' }
 sub smtpagent   { 'US::Yahoo' }
@@ -48,9 +45,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -75,26 +72,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -165,7 +149,8 @@ sub scan {
         $e->{'spec'} ||= 'SMTP';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MSP/US/Zoho.pm
+++ b/lib/Sisimai/MSP/US/Zoho.pm
@@ -18,14 +18,10 @@ my $Re1 = {
     'rfc822' => qr/\AReceived:[ \t]*from mail[.]zoho[.]com/,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'expired' => qr/Host not reachable/
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Zoho Mail: https://www.zoho.com' }
 sub smtpagent   { 'US::Zoho' }
@@ -57,9 +53,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $qprintable = 0;
@@ -85,26 +81,13 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
+
         } else {
             # Before "message/rfc822"
             next unless $readcursor & $Indicators->{'deliverystatus'};
@@ -185,7 +168,8 @@ sub scan {
         $e->{'spec'} ||= 'SMTP';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/Activehunter.pm
+++ b/lib/Sisimai/MTA/Activehunter.pm
@@ -15,8 +15,6 @@ my $Re1 = {
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'TransWARE Active!hunter' };
 sub smtpagent   { 'Activehunter' }
@@ -44,9 +42,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -71,26 +69,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -143,7 +127,8 @@ sub scan {
 
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/ApacheJames.pm
+++ b/lib/Sisimai/MTA/ApacheJames.pm
@@ -19,8 +19,6 @@ my $Re1 = {
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Java Apache Mail Enterprise Server' }
 sub smtpagent   { 'ApacheJames' }
@@ -51,9 +49,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $diagnostic = '';    # (String) Alternative diagnostic message
@@ -81,26 +79,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -167,10 +151,10 @@ sub scan {
     require Sisimai::String;
     require Sisimai::SMTP::Status;
 
-    unless( $rfc822part =~ m/\bSubject:/ ) {
+    unless( grep { $_ =~ /^Subject:/ } @$rfc822list ) {
         # Set the value of $subjecttxt as a Subject if there is no original
         # message in the bounce mail.
-        $rfc822part .= sprintf( "Subject: %s\n", $subjecttxt );
+        push @$rfc822list, sprintf( "Subject: %s", $subjecttxt );
     }
 
     for my $e ( @$dscontents ) {
@@ -185,7 +169,8 @@ sub scan {
         $e->{'diagnosis'} = Sisimai::String->sweep( $e->{'diagnosis'} || $diagnostic );
         $e->{'status'}    = Sisimai::SMTP::Status->find( $e->{'diagnosis'} );
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/Courier.pm
+++ b/lib/Sisimai/MTA/Courier.pm
@@ -28,7 +28,6 @@ my $Re1 = {
     }x,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     # courier/module.esmtp/esmtpclient.c:526| hard_error(del, ctf, "No such domain.");
     'hostunknown' => qr{
@@ -40,15 +39,11 @@ my $ReFailure = {
         \AThis[ ]domain's[ ]DNS[ ]violates[ ]RFC[ ]1035[.]\z
     }x,
 };
-
 my $ReDelayed = {
     # courier/module.esmtp/esmtpclient.c:535| soft_error(del, ctf, "DNS lookup failed.");
     'networkerror' => qr/\ADNS[ ]lookup[ ]failed[.]\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Courier MTA' }
 sub smtpagent   { 'Courier' }
@@ -82,9 +77,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
@@ -118,26 +113,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -294,7 +275,9 @@ sub scan {
         $e->{'agent'}     = __PACKAGE__->smtpagent;
         $e->{'command'} ||= $commandtxt || '';
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/Domino.pm
+++ b/lib/Sisimai/MTA/Domino.pm
@@ -173,12 +173,12 @@ sub scan {
 
         $e->{'spec'} = $e->{'reason'} eq 'mailererror' ? 'X-UNIX' : 'SMTP';
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
+    }
 
-        unless( grep { $_ =~ /^Subject:/ } @$rfc822list ) {
-            # Set the value of $subjecttxt as a Subject if there is no original
-            # message in the bounce mail.
-            push @$rfc822list, sprintf( "Subject: %s", $subjecttxt );
-        }
+    unless( grep { $_ =~ /^Subject:/ } @$rfc822list ) {
+        # Set the value of $subjecttxt as a Subject if there is no original
+        # message in the bounce mail.
+        push @$rfc822list, sprintf( "Subject: %s", $subjecttxt );
     }
 
     $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );

--- a/lib/Sisimai/MTA/Domino.pm
+++ b/lib/Sisimai/MTA/Domino.pm
@@ -12,7 +12,6 @@ my $Re1 = {
     'rfc822'  => qr|\AContent-Type: message/delivery-status\z|,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'userunknown' => qr{(?>
          not[ ]listed[ ]in[ ](?:
@@ -29,10 +28,7 @@ my $ReFailure = {
         Several[ ]matches[ ]found[ ]in[ ]Domino[ ]Directory
     }x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'IBM Domino Server' }
 sub smtpagent   { 'Domino' }
@@ -59,9 +55,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $subjecttxt = '';    # (String) The value of Subject:
@@ -93,27 +89,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -193,13 +174,15 @@ sub scan {
         $e->{'spec'} = $e->{'reason'} eq 'mailererror' ? 'X-UNIX' : 'SMTP';
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
 
-        unless( $rfc822part =~ m/\bSubject:/ ) {
-            # Fallback: Add the value of Subject as a Subject header
-            $rfc822part .= sprintf( "Subject: %s\n", $subjecttxt );
+        unless( grep { $_ =~ /^Subject:/ } @$rfc822list ) {
+            # Set the value of $subjecttxt as a Subject if there is no original
+            # message in the bounce mail.
+            push @$rfc822list, sprintf( "Subject: %s", $subjecttxt );
         }
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/Exim.pm
+++ b/lib/Sisimai/MTA/Exim.pm
@@ -128,10 +128,7 @@ my $ReDelayed = qr{(?:
     |Message[ ].+[ ](?:has[ ]been[ ]frozen|was[ ]frozen[ ]on[ ]arrival[ ]by[ ])
     )
 }x;
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Exim' }
 sub smtpagent   { 'Exim' }
@@ -164,9 +161,9 @@ sub scan {
     require Sisimai::String;
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $localhost0 = '';    # (String) Local MTA
@@ -202,26 +199,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -539,7 +522,8 @@ sub scan {
         $e->{'action'}  ||= 'failed' if $e->{'status'} =~ m/\A[45]/;
         $e->{'command'} ||= '';
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/IMailServer.pm
+++ b/lib/Sisimai/MTA/IMailServer.pm
@@ -5,8 +5,8 @@ use strict;
 use warnings;
 
 my $Re0 = {
-    'x-mailer' => qr/\A[<]SMTP32 v[\d.]+[>]\z/,
-    'subject'  => qr/\AUndeliverable Mail\z/,
+    'x-mailer' => qr/\A[<]SMTP32 v[\d.]+[>][ ]*\z/,
+    'subject'  => qr/\AUndeliverable Mail[ ]*\z/,
 };
 my $Re1 = {
     'begin'  => qr/\A\z/,    # Blank line
@@ -123,7 +123,7 @@ sub scan {
             # Original message follows.
             $v = $dscontents->[ -1 ];
 
-            if( $e =~ m/\A(.+)[ ](.+)[:][ \t]*([^ ]+[@][^ ]+)\z/ ) {
+            if( $e =~ m/\A(.+)[ ](.+)[:][ \t]*([^ ]+[@][^ ]+)/ ) {
                 # Unknown user: kijitora@example.com
                 if( length $v->{'recipient'} ) {
                     # There are multiple recipient addresses in the message body.

--- a/lib/Sisimai/MTA/IMailServer.pm
+++ b/lib/Sisimai/MTA/IMailServer.pm
@@ -14,7 +14,6 @@ my $Re1 = {
     'rfc822' => qr/\AOriginal message follows[.]\z/,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReSMTP = {
     'conn' => qr{(?:
          SMTP[ ]connection[ ]failed,
@@ -26,7 +25,6 @@ my $ReSMTP = {
     'rcpt' => qr|Additional RCPT TO generated following response:|,
     'data' => qr|DATA command generated response:|,
 };
-
 my $ReFailure = {
     'hostunknown' => qr{
         Unknown[ ]host
@@ -49,10 +47,7 @@ my $ReFailure = {
         \ADelivery[ ]failed[ ]\d+[ ]attempts
     }x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'IPSWITCH IMail Server' }
 sub smtpagent   { 'IMailServer' }
@@ -85,9 +80,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -112,27 +107,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -216,7 +196,8 @@ sub scan {
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/InterScanMSS.pm
+++ b/lib/Sisimai/MTA/InterScanMSS.pm
@@ -21,8 +21,6 @@ my $Re1 = {
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Trend Micro InterScan Messaging Security Suite' }
 sub smtpagent   { 'InterScanMSS' }
@@ -52,9 +50,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -79,26 +77,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -154,7 +138,8 @@ sub scan {
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/MailFoundry.pm
+++ b/lib/Sisimai/MTA/MailFoundry.pm
@@ -14,10 +14,7 @@ my $Re1 = {
     'rfc822' => qr|\AContent-Type: message/rfc822\z|,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'MailFoundry' }
 sub smtpagent   { 'MailFoundry' }
@@ -45,9 +42,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -72,26 +69,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -161,7 +144,8 @@ sub scan {
         $e->{'action'} = 'failed' if $e->{'status'} =~ m/\A[45]/;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/MailMarshalSMTP.pm
+++ b/lib/Sisimai/MTA/MailMarshalSMTP.pm
@@ -14,10 +14,7 @@ my $Re1 = {
     'rcpts'    => qr/\AThe following recipients were affected:/,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Trustwave Secure Email Gateway' }
 sub smtpagent   { 'MailMarshalSMTP' }
@@ -46,9 +43,9 @@ sub scan {
     require Sisimai::String;
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $boundary00 = '';    # (String) Boundary string
@@ -78,27 +75,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -156,7 +138,7 @@ sub scan {
                         # Original Sender:    <originalsender@example.com>
                         # Use this line instead of "From" header of the original
                         # message.
-                        $rfc822part .= sprintf("From: %s\n", $1 );
+                        push @$rfc822list, sprintf("From: %s", $1 );
 
                     } elsif( $e =~ m/\ASender-MTA:[ \t]+[<](.+)[>]\z/ ) {
                         # Sender-MTA:         <10.11.12.13>
@@ -189,7 +171,8 @@ sub scan {
         $e->{'action'}    = 'failed' if $e->{'status'} =~ m/\A[45]/;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/McAfee.pm
+++ b/lib/Sisimai/MTA/McAfee.pm
@@ -14,7 +14,6 @@ my $Re1 = {
     'rfc822'  => qr|\AContent-Type: message/rfc822\z|,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'userunknown' => qr{(?:
          User[ ][(].+[@].+[)][ ]unknown[.]
@@ -22,10 +21,7 @@ my $ReFailure = {
         )
     }x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'McAfee Email Appliance' }
 sub smtpagent   { 'McAfee' }
@@ -58,9 +54,9 @@ sub scan {
     require Sisimai::Address;
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $diagnostic = '';    # (String) Alternative diagnostic message
@@ -88,26 +84,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -194,7 +176,9 @@ sub scan {
         $e->{'status'} = Sisimai::SMTP::Status->find( $e->{'diagnosis'} );
         $e->{'spec'}   = $e->{'reason'} eq 'mailererror' ? 'X-UNIX' : 'SMTP';
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/MessagingServer.pm
+++ b/lib/Sisimai/MTA/MessagingServer.pm
@@ -14,14 +14,10 @@ my $Re1 = {
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
     'rfc822'   => qr!\A(?:Content-type:[ \t]*message/rfc822|Return-path:[ \t]*)!x,
 };
-
 my $ReFailure = {
     'hostunknown' => qr{Illegal[ ]host/domain[ ]name[ ]found}x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Oracle Communications Messaging Server' }
 sub smtpagent   { 'MessagingServer' }
@@ -52,9 +48,9 @@ sub scan {
     require Sisimai::Address;
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -79,26 +75,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -227,7 +209,8 @@ sub scan {
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/OpenSMTPD.pm
+++ b/lib/Sisimai/MTA/OpenSMTPD.pm
@@ -39,7 +39,6 @@ my $Re1 = {
     'rfc822' => qr/\A[ \t]*Below is a copy of the original message:\z/,
     'endof'  => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $ReFailure = {
     'expired' => qr{
         # smtpd/queue.c:221|  envelope_set_errormsg(&evp, "Envelope expired");
@@ -76,10 +75,7 @@ my $ReFailure = {
         Could[ ]not[ ]retrieve[ ]credentials
     }x,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'OpenSMTPD' }
 sub smtpagent   { 'OpenSMTPD' }
@@ -108,9 +104,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -135,26 +131,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -213,7 +195,8 @@ sub scan {
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/Postfix.pm
+++ b/lib/Sisimai/MTA/Postfix.pm
@@ -31,10 +31,7 @@ my $Re1 = {
     'rfc822'  => qr!\AContent-Type:[ \t]*(?:message/rfc822|text/rfc822-headers)\z!x,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Postfix' }
 sub smtpagent   { 'Postfix' }
@@ -61,9 +58,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my @commandset = ();    # (Array) ``in reply to * command'' list
@@ -97,26 +94,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.*\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -220,7 +203,7 @@ sub scan {
 
                     } elsif( $e =~ m/\A(X-Postfix-Sender):[ ]*rfc822;[ ]*(.+)\z/ ) {
                         # X-Postfix-Sender: rfc822; shironeko@example.org
-                        $rfc822part .= sprintf( "%s: %s\n", $1, $2 );
+                        push @$rfc822list, sprintf( "%s: %s", $1, $2 );
 
                     } else {
                         # Alternative error message and recipient
@@ -298,7 +281,8 @@ sub scan {
             $e->{'status'} = $r if length $r;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/Sendmail.pm
+++ b/lib/Sisimai/MTA/Sendmail.pm
@@ -19,10 +19,7 @@ my $Re1 = {
     'rfc822'  => qr{\AContent-Type:[ ]*(?:message/rfc822|text/rfc822-headers)\z},
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'V8Sendmail: /usr/sbin/sendmail' }
 sub smtpagent   { 'Sendmail' }
@@ -54,9 +51,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
 
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
@@ -93,26 +90,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -303,7 +286,8 @@ sub scan {
             }
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/SurfControl.pm
+++ b/lib/Sisimai/MTA/SurfControl.pm
@@ -14,10 +14,7 @@ my $Re1 = {
     'rfc822'   => qr|\AContent-Type: message/rfc822\z|,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'WebSense SurfControl' }
 sub smtpagent   { 'SurfControl' }
@@ -51,9 +48,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
 
@@ -80,26 +77,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -183,7 +166,8 @@ sub scan {
 
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/UserDefined.pm
+++ b/lib/Sisimai/MTA/UserDefined.pm
@@ -23,10 +23,7 @@ my $Re1 = {
     'rfc822'  => qr{\AContent-Type:[ ]*(?:message/rfc822|text/rfc822-headers)\z},
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Module decription' }
 sub smtpagent   { 'Module name' }
@@ -68,9 +65,9 @@ sub scan {
     #
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
 
@@ -92,7 +89,8 @@ sub scan {
     return undef unless $recipients;
 
     # 4. Return the following variable.
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/V5sendmail.pm
+++ b/lib/Sisimai/MTA/V5sendmail.pm
@@ -34,10 +34,7 @@ my $Re1 = {
     }x,
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Sendmail version 5' }
 sub smtpagent   { 'V5sendmail' }
@@ -64,9 +61,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my @responding = ();    # (Array) Responses from remote server
@@ -95,26 +92,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -176,10 +159,13 @@ sub scan {
 
     unless( $recipients ) {
         # Get the recipient address from the original message
-        if( $rfc822part =~ m/^To: (.+)$/m ) {
-            # The value of To: header in the original message
-            $dscontents->[0]->{'recipient'} = Sisimai::Address->s3s4( $1 );
-            $recipients = 1;
+        for my $e ( @$rfc822list ) {
+            if( $e =~ m/^To: (.+)$/ ) {
+                # The value of To: header in the original message
+                $dscontents->[0]->{'recipient'} = Sisimai::Address->s3s4( $1 );
+                $recipients = 1;
+                last;
+            }
         }
     }
     return undef unless $recipients;
@@ -218,7 +204,8 @@ sub scan {
         }
         delete $e->{'sessionerr'};
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/X1.pm
+++ b/lib/Sisimai/MTA/X1.pm
@@ -13,10 +13,7 @@ my $Re1 = {
     'endof'   => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
     'rfc822'  => qr/\AReceived: from \d+[.]\d+[.]\d+[.]\d/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Unknown MTA #1' }
 sub smtpagent   { 'X1' }
@@ -44,9 +41,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $datestring = '';    # (String) Date string
@@ -72,26 +69,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -144,7 +127,8 @@ sub scan {
         $e->{'date'}      = $datestring || '';
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/X2.pm
+++ b/lib/Sisimai/MTA/X2.pm
@@ -74,7 +74,7 @@ sub scan {
             # After "message/rfc822"
             unless( length $e ) {
                 $blanklines++;
-                last if $blanklines > 1;
+                last if $blanklines > 2;
                 next;
             }
             push @$rfc822list, $e;

--- a/lib/Sisimai/MTA/X2.pm
+++ b/lib/Sisimai/MTA/X2.pm
@@ -17,10 +17,7 @@ my $Re1 = {
     'rfc822'   => qr/\A--- Original message follows/,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Unknown MTA #2' }
 sub smtpagent   { 'X2' }
@@ -48,9 +45,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -75,26 +72,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -143,7 +126,8 @@ sub scan {
         $e->{'agent'}     = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/X3.pm
+++ b/lib/Sisimai/MTA/X3.pm
@@ -13,10 +13,7 @@ my $Re1 = {
     'rfc822'   => qr|\AContent-Type: message/rfc822|,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Unknown MTA #3' }
 sub smtpagent   { 'X3' }
@@ -44,9 +41,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -71,26 +68,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -158,7 +141,8 @@ sub scan {
         $e->{'action'}    = 'failed' if $e->{'status'} =~ m/\A[45]/;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/X4.pm
+++ b/lib/Sisimai/MTA/X4.pm
@@ -146,11 +146,8 @@ my $ReFailure = {
 };
 
 # qmail-send.c:922| ... (&dline[c],"I'm not going to try again; this message has been in the queue too long.\n")) nomem();
-my $ReDelayed = qr{this[ ]message[ ]has[ ]been[ ]in[ ]the[ ]queue[ ]too[ ]long[.]\z}x;
-
+my $ReDelayed  = qr{this[ ]message[ ]has[ ]been[ ]in[ ]the[ ]queue[ ]too[ ]long[.]\z}x;
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Unknown MTA #4 qmail clones' }
 sub smtpagent   { 'X4' }
@@ -184,9 +181,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -211,26 +208,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -350,7 +333,8 @@ sub scan {
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/X5.pm
+++ b/lib/Sisimai/MTA/X5.pm
@@ -13,10 +13,7 @@ my $Re1 = {
     'rfc822'   => qr|\AContent-Type: message/rfc822|,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Unknown MTA #5' }
 sub smtpagent   { 'X5' }
@@ -65,9 +62,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
 
@@ -151,26 +148,12 @@ sub scan {
             next unless $recipients;
             next unless $readcursor & $Indicators->{'deliverystatus'};
 
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
         }
     } continue {
         # Save the current line for the next loop
@@ -195,7 +178,8 @@ sub scan {
         $e->{'agent'}       = __PACKAGE__->smtpagent;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/MTA/mFILTER.pm
+++ b/lib/Sisimai/MTA/mFILTER.pm
@@ -16,10 +16,7 @@ my $Re1 = {
     'rfc822'   => qr/\A-------original (?:message|mail info)\z/,
     'endof'    => qr/\A__END_OF_EMAIL_MESSAGE__\z/,
 };
-
 my $Indicators = __PACKAGE__->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Digital Arts m-FILTER' }
 sub smtpagent   { 'm-FILTER' }
@@ -51,9 +48,9 @@ sub scan {
 
     my $dscontents = []; push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $markingset = { 'diagnosis' => 0, 'command' => 0 };
@@ -76,27 +73,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -182,7 +164,8 @@ sub scan {
         $e->{'action'}    = 'failed' if $e->{'status'} =~ m/\A[45]/;
     }
 
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -140,7 +140,6 @@ sub make {
     # 5. Rewrite headers of the original message in the body part
     my $rfc822part = $bouncedata->{'rfc822'} || $aftersplit->{'body'};
     $processing->{'rfc822'} = __PACKAGE__->takeapart( \$rfc822part );
-
     return $processing;
 }
 
@@ -157,8 +156,8 @@ sub divideup {
     my $pseudofrom = 'MAILER-DAEMON Tue Feb 11 00:00:00 2014';
     my $aftersplit = { 'from' => '', 'header' => '', 'body' => '' };
 
-    $$email =~ s/[ \t]+$//gm; 
-    $$email =~ s/^[ \t]+$//gm;
+    $$email =~ s/\r\n/\n/gm if $$email =~ m/\r\n/;
+    $$email =~ s/[ \t]+$//gm if $$email =~ m/[ \t]+$/;
     @hasdivided = split( "\n", $$email );
     return {} unless scalar @hasdivided;
 
@@ -170,8 +169,6 @@ sub divideup {
 
     SPLIT_EMAIL: for my $e ( @hasdivided ) {
         # Split email data to headers and a body part.
-        $e =~ y/\r\n//d;
-
         if( $readcursor & $Indicators->{'endof'} ) {
             # The body part of the email
             $aftersplit->{'body'} .= $e."\n";

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -171,7 +171,6 @@ sub divideup {
     SPLIT_EMAIL: for my $e ( @hasdivided ) {
         # Split email data to headers and a body part.
         $e =~ y/\r\n//d;
-        $e =~ s/[ \t]+\z//; # Remove traling space and tab characters
 
         if( $readcursor & $Indicators->{'endof'} ) {
             # The body part of the email
@@ -301,7 +300,6 @@ sub takeapart {
             # Header
             my $lhs = lc $1;
             my $rhs = $2;
-
             $previousfn = '';
 
             next unless exists $RFC822Head->{ $lhs };

--- a/lib/Sisimai/RFC3464.pm
+++ b/lib/Sisimai/RFC3464.pm
@@ -20,7 +20,6 @@ my $Re0 = {
         )
     }xi,
 };
-
 my $Re1 = {
     'begin'  => qr{\A(?>
          Content-Type:[ ]*(?:
@@ -42,10 +41,7 @@ my $Re1 = {
     'error'  => qr/\A(?:[45]\d\d[ \t]+|[<][^@]+[@][^@]+[>]:?[ \t]+)/i,
     'command'=> qr/[ ](RCPT|MAIL|DATA)[ ]+command\b/,
 };
-
 my $Indicators = Sisimai::MTA->INDICATORS;
-my $LongFields = Sisimai::RFC5322->LONGFIELDS;
-my $RFC822Head = Sisimai::RFC5322->HEADERFIELDS;
 
 sub description { 'Fallback Module for MTAs' };
 sub smtpagent   { 'RFC3464' };
@@ -77,9 +73,9 @@ sub scan {
     my $dscontents = []; push @$dscontents, Sisimai::MTA->DELIVERYSTATUS;
     my @hasdivided = split( "\n", $$mbody );
     my $scannedset = Sisimai::MDA->scan( $mhead, $mbody );
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
+    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
+    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $connheader = {
@@ -111,26 +107,12 @@ sub scan {
 
         if( $readcursor & $Indicators->{'message-rfc822'} ) {
             # After "message/rfc822"
-            if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*(.+)\z/ ) {
-                # Get required headers only
-                my $lhs = lc $1;
-                $previousfn = '';
-                next unless exists $RFC822Head->{ $lhs };
-
-                $previousfn  = $lhs;
-                $rfc822part .= $e."\n";
-
-            } elsif( $e =~ m/\A[ \t]+/ ) {
-                # Continued line from the previous line
-                next if $rfc822next->{ $previousfn };
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-
-            } else {
-                # Check the end of headers in rfc822 part
-                next unless exists $LongFields->{ $previousfn };
-                next if length $e;
-                $rfc822next->{ $previousfn } = 1;
+            unless( length $e ) {
+                $blanklines++;
+                last if $blanklines > 1;
+                next;
             }
+            push @$rfc822list, $e;
 
         } else {
             # Before "message/rfc822"
@@ -485,7 +467,8 @@ sub scan {
         $e->{'date'}  ||= $mhead->{'date'};
         $e->{'spec'}  ||= 'SMTP';
     }
-    return { 'ds' => $dscontents, 'rfc822' => $rfc822part };
+    $rfc822part = Sisimai::RFC5322->weedout( $rfc822list );
+    return { 'ds' => $dscontents, 'rfc822' => $$rfc822part };
 }
 
 1;

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -30,6 +30,7 @@ BUILD_REGULAR_EXPRESSIONS: {
     $Re->{'domain'}  = qr/$domain/o;
 }
 
+my $LONGHEADERS = __PACKAGE__->LONGFIELDS;
 my $HEADERINDEX = {};
 my $HEADERTABLE = {
     'messageid' => [ 'Message-Id' ],
@@ -208,8 +209,6 @@ sub weedout {
     my $argv1 = shift // return undef;
     return undef unless ref $argv1 eq 'ARRAY';
 
-    my $rfc822head = __PACKAGE__->HEADERFIELDS;
-    my $longfields = __PACKAGE__->LONGFIELDS;
     my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
     my $rfc822part = '';    # (String) message/rfc822-headers part
     my $previousfn = '';    # (String) Previous field name
@@ -220,7 +219,7 @@ sub weedout {
             # Get required headers
             my $lhs = lc $1;
             $previousfn = '';
-            next unless exists $rfc822head->{ $lhs };
+            next unless exists $HEADERINDEX->{ $lhs };
 
             $previousfn  = $lhs;
             $rfc822part .= $e."\n";
@@ -228,11 +227,11 @@ sub weedout {
         } elsif( $e =~ m/\A[ \t]+/ ) {
             # Continued line from the previous line
             next if $rfc822next->{ $previousfn };
-            $rfc822part .= $e."\n" if exists $longfields->{ $previousfn };
+            $rfc822part .= $e."\n" if exists $LONGHEADERS->{ $previousfn };
 
         } else {
             # Check the end of headers in rfc822 part
-            next unless exists $longfields->{ $previousfn };
+            next unless exists $LONGHEADERS->{ $previousfn };
             next if length $e;
             $rfc822next->{ $previousfn } = 1;
         }

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -105,13 +105,13 @@ sub is_mailerdaemon {
     #                           1: Mailer-daemon
     my $class = shift;
     my $email = shift // return 0;
-    my $rxmds = qr/(?:
-         mailer-daemon[@]
-        |[<(]mailer-daemon[)>]
-        |\Amailer-daemon\z
-        |[ ]?mailer-daemon[ ])
-    /xi;
-
+    my $rxmds = qr{(?>
+         (?:mailer-daemon|postmaster)[@]
+        |[<(](?:mailer-daemon|postmaster)[)>]
+        |\A(?:mailer-daemon|postmaster)\z
+        |[ ]?mailer-daemon[ ]
+        )
+    }xi;
     return 1 if $email =~ $rxmds;
     return 0;
 }

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -215,7 +215,7 @@ sub weedout {
 
     for my $e ( @$argv1 ) {
         # After "message/rfc822"
-        if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+\z/ ) {
+        if( $e =~ m/\A([-0-9A-Za-z]+?)[:][ ]*.+/ ) {
             # Get required headers
             my $lhs = lc $1;
             $previousfn = '';

--- a/t/010-address.t
+++ b/t/010-address.t
@@ -2,6 +2,7 @@ use strict;
 use Test::More;
 use lib qw(./lib ./blib/lib);
 use Sisimai::Address;
+use Sisimai::RFC5322;
 
 my $PackageName = 'Sisimai::Address';
 my $MethodNames = {
@@ -25,6 +26,7 @@ MAKE_TEST: {
         '8be@example.gov', 'nekochan@example.jp', 'neko@example.com', 'neko@example.org',
         'neko@example.net', 'neko@example.edu', 'neko@example.cat', 'neko@example.mil',
         'neko@example.gov', 'neko@example.int', 'neko@example.gl', '"neko.."@example.jp',
+        'MAILER-DAEMON', 'postmaster'
     ];
     my $emailfroms = [
         q|"Neko" <neko@example.jp>|,
@@ -51,6 +53,8 @@ MAKE_TEST: {
         q|{neko@example.int}|,
         q|&lt;neko@example.gl&gt;|,
         q|"neko.."@example.jp|,
+        q|Mail Delivery Subsystem <MAILER-DAEMON>|,
+        q|postmaster|,
     ];
     my $isnotemail = [
         1, 'neko', 'cat%neko.jp', '', undef, {},
@@ -75,7 +79,9 @@ MAKE_TEST: {
         my $z = [ split( '@', $x ) ];
         isa_ok $y, $PackageName;
         is $y->user, $z->[0], '->user = '.$z->[0];
-        is $y->host, $z->[1], '->host = '.$z->[1];
+        unless( Sisimai::RFC5322->is_mailerdaemon($e) ) {
+            is $y->host, $z->[1], '->host = '.$z->[1];
+        }
         is $y->address, $x, '->address = '.$x;
         is $y->verp, '', '->verp = ""';
         is $y->alias, '', '->alias = ""';

--- a/t/031-rfc5322.t
+++ b/t/031-rfc5322.t
@@ -65,6 +65,9 @@ MAKE_TEST: {
         'mailer-daemon@example.jp', 
         'MAILER-DAEMON@example.cat',
         'Mailer-Daemon <postmaster@example.org>',
+        'MAILER-DAEMON',
+        'postmaster',
+        'postmaster@example.org',
     ];
 
     for my $e ( @$emailaddrs ) {

--- a/t/031-rfc5322.t
+++ b/t/031-rfc5322.t
@@ -7,7 +7,8 @@ my $PackageName = 'Sisimai::RFC5322';
 my $MethodNames = {
     'class' => [ 
         'HEADERFIELDS', 'LONGFIELDS',
-        'is_emailaddress', 'is_domainpart', 'is_mailerdaemon', 'received'
+        'is_emailaddress', 'is_domainpart', 'is_mailerdaemon', 'received',
+        'weedout',
     ],
     'object' => [],
 };
@@ -121,7 +122,32 @@ MAKE_TEST: {
             ok $f =~ qr/\A[-.0-9A-Za-z]+\z/, 'Regular expression';
         }
     }
-    
+
+    my $rfc822text = <<'EOR';
+Return-Path: <shironeko@mx.example.co.jp>
+Received: from mx.example.co.jp (localhost [127.0.0.1])
+	by mx.example.co.jp (8.13.9/8.13.1) with ESMTP id fffff000000001
+	for <kijitora@example.net>; Thu, 9 Apr 2014 23:34:45 +0900
+Received: (from shironeko@localhost)
+	by mx.example.co.jp (8.13.9/8.13.1/Submit) id fff0000000003
+	for kijitora@example.net; Thu, 9 Apr 2014 23:34:45 +0900
+Date: Thu, 9 Apr 2014 23:34:45 +0900
+Message-Id: <0000000011111.fff0000000003@mx.example.co.jp>
+Content-Type: text/plain
+MIME-Version: 1.0
+From: Shironeko <shironeko@example.co.jp>
+To: Kijitora <shironeko@example.co.jp>
+Subject: Nyaaaan
+
+Nyaaan
+EOR
+    my $rfc822part = Sisimai::RFC5322->weedout( [split("\n", $rfc822text)] );
+    isa_ok $rfc822part, 'SCALAR';
+    ok length $$rfc822part;
+    like $$rfc822part, qr/^From:/m;
+    like $$rfc822part, qr/^Date:/m;
+    unlike $$rfc822part, qr/^MIME-Version:/m;
+    unlike $$rfc822part, qr/^Received:/m;
 }
 
 done_testing;

--- a/t/040-message.t
+++ b/t/040-message.t
@@ -68,7 +68,7 @@ MAKE_TEST: {
     }
     isa_ok $p->header->{'received'}, 'ARRAY';
 
-    for my $e ( 'return-path', 'delivered-to', 'to', 'subject', 'date', 'from', 'message-id', 'reply-to' ) {
+    for my $e ( qw|return-path to subject date from message-id| ) {
         my $h = $p->rfc822->{ $e };
         ok length $h, $e;
     }

--- a/t/510-mta-userdefined.t
+++ b/t/510-mta-userdefined.t
@@ -62,7 +62,7 @@ MAKE_TEST: {
             ok length $e->recipient->address, 'recipient->address = '.$e->recipient->address;
             is $e->recipient->host, $e->destination, 'destination = '.$e->destination;
 
-            ok length $e->subject, 'subject = '.$e->subject;
+            ok length $e->subject;
             ok length $e->softbounce, 'softbounce = '.$e->softbounce;
             ok length $e->diagnosticcode, 'diagnosticcode = '.$e->diagnosticcode;
             ok length $e->diagnostictype, 'diagnostictype = '.$e->diagnostictype;

--- a/xt/020-mta-children.t
+++ b/xt/020-mta-children.t
@@ -4,6 +4,7 @@ use lib qw(./lib ./blib/lib);
 use Sisimai::Data;
 use Sisimai::Mail;
 use Sisimai::Message;
+use Sisimai::RFC5322;
 use Module::Load;
 
 my $R = {
@@ -988,7 +989,6 @@ for my $x ( keys %$R ) {
     use_ok $M;
 
     if( -d $d ) {
-
         my $h = undef;
         my $n = 0;
         ok $d, sprintf( "%s %s", $x, $d );
@@ -1012,8 +1012,9 @@ for my $x ( keys %$R ) {
                 my $v = Sisimai::Data->make( 'data' => $p, 'delivered' => 1 );
                 my $y = undef;
 
-                # is ref($p), 'Sisimai::Message', sprintf( "[%s] %s/%s(Sisimai::Message)", $n, $e, $x );
-                # is ref($v), 'ARRAY', sprintf( "[%s] %s/%s(ARRAY)", $n, $e, $x );
+                next unless $p;
+                is ref($p), 'Sisimai::Message', sprintf( "[%s] %s/%s(Sisimai::Message)", $n, $e, $x );
+                is ref($v), 'ARRAY', sprintf( "[%s] %s/%s(ARRAY)", $n, $e, $x );
                 # ok scalar @$v, sprintf( "[%s] %s/%s(%d)", $n, $e, $x, scalar @$v );
 
                 for my $ee ( @$v ) {
@@ -1094,7 +1095,9 @@ for my $x ( keys %$R ) {
                     like $y->day,  qr/\A\w+\z/,  sprintf( "[%s] %s/%s->timestamp->day = %s", $n, $e, $x, $y->day );
 
                     isa_ok $ee->addresser, 'Sisimai::Address'; $y = $ee->addresser;
-                    ok length  $y->host,            sprintf( "[%s] %s/%s->addresser->host = %s", $n, $e, $x, $y->host );
+                    unless( Sisimai::RFC5322->is_mailerdaemon($y->address) ) {
+                        ok length $y->host,         sprintf( "[%s] %s/%s->addresser->host = %s", $n, $e, $x, $y->host );
+                    }
                     ok length  $y->user,            sprintf( "[%s] %s/%s->addresser->user = %s", $n, $e, $x, $y->user );
                     ok length  $y->address,         sprintf( "[%s] %s/%s->addresser->address = %s", $n, $e, $x, $y->address );
                     ok defined $y->verp,            sprintf( "[%s] %s/%s->addresser->verp = %s", $n, $e, $x, $y->verp );

--- a/xt/021-mta-relative.t
+++ b/xt/021-mta-relative.t
@@ -304,8 +304,9 @@ for my $x ( keys %$R ) {
                 my $v = Sisimai::Data->make( 'data' => $p, 'delivered' => 1 );
                 my $y = undef;
 
-                # is ref($p), 'Sisimai::Message', sprintf( "[%s] %s/%s(Sisimai::Message)", $n, $e, $x );
-                # is ref($v), 'ARRAY', sprintf( "[%s] %s/%s(ARRAY)", $n, $e, $x );
+                next unless $p;
+                is ref($p), 'Sisimai::Message', sprintf( "[%s] %s/%s(Sisimai::Message)", $n, $e, $x );
+                is ref($v), 'ARRAY', sprintf( "[%s] %s/%s(ARRAY)", $n, $e, $x );
                 # ok scalar @$v, sprintf( "[%s] %s/%s(%d)", $n, $e, $x, scalar @$v );
 
                 for my $ee ( @$v ) {

--- a/xt/022-msp-children.t
+++ b/xt/022-msp-children.t
@@ -343,8 +343,9 @@ for my $x ( keys %$R ) {
                 my $v = Sisimai::Data->make( 'data' => $p );
                 my $y = undef;
 
-                # is ref($p), 'Sisimai::Message', sprintf( "[%s] %s/%s(Sisimai::Message)", $n, $e, $x );
-                # is ref($v), 'ARRAY', sprintf( "[%s] %s/%s(ARRAY)", $n, $e, $x );
+                next unless $p;
+                is ref($p), 'Sisimai::Message', sprintf( "[%s] %s/%s(Sisimai::Message)", $n, $e, $x );
+                is ref($v), 'ARRAY', sprintf( "[%s] %s/%s(ARRAY)", $n, $e, $x );
                 # ok scalar @$v, sprintf( "[%s] %s/%s(%d)", $n, $e, $x, scalar @$v );
 
                 for my $ee ( @$v ) {


### PR DESCRIPTION
* Implement Sisimai::RFC5322->weedout() for picking up necessary fields only
* Call Sisimai::RFC5322->weedout() from each MTA/MSP module
* About 20% faster than before
* Decreased about 5% of codes