### PR TITLE
Fix bug causing subject conversion failure when eval state is dirty

### DIFF
--- a/lib/Sisimai/MIME.pm
+++ b/lib/Sisimai/MIME.pm
@@ -78,10 +78,10 @@ sub mimedecode {
             eval {
                 Encode::from_to( $decodedtext1, $characterset, 'utf8' );
             };
+            $decodedtext1 = 'FAILED TO CONVERT THE SUBJECT' if $@;
         }
     }
 
-    $decodedtext1 = 'FAILED TO CONVERT THE SUBJECT' if $@;
     $utf8decoded1 = Encode::decode_utf8 $decodedtext1;
     return $utf8decoded1;
 }


### PR DESCRIPTION
It is unsafe to test $@ anywhere except immediately after an eval,
because $@ may be set from an eval elsewhere, such as in the calling
code.

Moving this $@ test right after the eval block stops properly
converted subjects from being wrongly flagged as errors.