### PR TITLE
Less regular expression (follow up PR #268)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,14 @@ RELEASE NOTES for Perl version of Sisimai
 - releases: "https://github.com/sisimai/p5-Sisimai/releases"
 - download: "https://metacpan.org/pod/Sisimai"
 
+v4.22.5p1
+--------------------------------------------------------------------------------
+- release: ""
+- version: ""
+- changes:
+  - #271 Most `Module::Load::load` have been replaced with `require`.
+  - #272 Fix bug in Sisimai::MIME->qprintd().
+
 v4.22.5
 --------------------------------------------------------------------------------
 - release: "Fri, 30 Mar 2018 12:29:16 +0900 (JST)"

--- a/lib/Sisimai/Reason/Filtered.pm
+++ b/lib/Sisimai/Reason/Filtered.pm
@@ -13,29 +13,21 @@ sub match {
     # @since v4.0.0
     my $class = shift;
     my $argv1 = shift // return undef;
-    my $regex = qr{(?>
-         because[ ]the[ ]recipient[ ]is[ ]only[ ]accepting[ ]mail[ ]from[ ]
-            specific[ ]email[ ]addresses    # AOL Phoenix
-        |bounced[ ]address  # SendGrid|a message to an address has previously been Bounced.
-        |due[ ]to[ ]extended[ ]inactivity[ ]new[ ]mail[ ]is[ ]not[ ]currently[ ]
-            being[ ]accepted[ ]for[ ]this[ ]mailbox
-        |has[ ]restricted[ ]sms[ ]e-mail    # AT&T
-        |http://postmaster[.]facebook[.]com/.+refused[ ]due[ ]to[ ]recipient[ ]preferences # Facebook
-        |is[ ]not[ ]accepting[ ]any[ ]mail
-        |permanent[ ]failure[ ]for[ ]one[ ]or[ ]more[ ]recipients[ ][(].+:blocked[)]
-        |resolver[.]rst[.]notauthorized # Microsoft Exchange
-        |this[ ]account[ ]is[ ]protected[ ]by
-        |user[ ](?:
-             not[ ]found  # Filter on MAIL.RU
-            |reject
-            )
-        |we[ ]failed[ ]to[ ]deliver[ ]mail[ ]because[ ]the[ ]following[ ]address
-            [ ]recipient[ ]id[ ]refuse[ ]to[ ]receive[ ]mail    # Willcom
-        |you[ ]have[ ]been[ ]blocked[ ]by[ ]the[ ]recipient
-        )
-    }x;
-
-    return 1 if $argv1 =~ $regex;
+    my $index = [
+        'because the recipient is only accepting mail from specific email addresses',   # AOL Phoenix
+        'bounced address',  # SendGrid|a message to an address has previously been Bounced.
+        'due to extended inactivity new mail is not currently being accepted for this mailbox',
+        'has restricted sms e-mail',    # AT&T
+        'is not accepting any mail',
+        'refused due to recipient preferences', # Facebook
+        'resolver.rst.notauthorized',   # Microsoft Exchange
+        'this account is protected by',
+        'user not found',   # Filter on MAIL.RU
+        'user reject',
+        'we failed to deliver mail because the following address recipient id refuse to receive mail',  # Willcom
+        'you have been blocked by the recipient',
+    ];
+    return 1 if grep { rindex($argv1, $_) > -1 } @$index;
     return 0;
 }
 

--- a/lib/Sisimai/Reason/SpamDetected.pm
+++ b/lib/Sisimai/Reason/SpamDetected.pm
@@ -62,6 +62,7 @@ sub match {
             |filters[ ]rate[ ]at[ ]and[ ]above[ ].+[ ]percent[ ]probability[ ]of[ ]being[ ]spam
             |system[ ]has[ ]detected[ ]that[ ]this[ ]message[ ]is
             )
+        |permanent[ ]failure[ ]for[ ]one[ ]or[ ]more[ ]recipients[ ][(].+:blocked[)]
         |probable[ ]spam
         |reject[ ]bulk[.]advertising
         |reject,.+[ ][-][ ]spam[.][ ]


### PR DESCRIPTION
- Sisimai::Reason::Filtered (Error message patterns have been converted to fixed strings)
- `Permanent failure for one or more recipients (***@***.***:blocked)` may be "spamdetected"