### PR TITLE
Exchange 550 5.4.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ v4.25.0p3
     header of the original message.
   - #316 Update error messages for Low Reputation Error from Gmail.
   - Fix code for checking `rhost` value at `Sisimai::Rhost`.
+  - Parser code to read bounce mails from m-FILTER at `Sisimai::Message::Email`
+    has been improved. Thanks to Nomura Research Institute, Ltd.
+  - Status 5.4.1 from Exchange Online is classified into "rejected" reason.
 
 v4.25.0
 --------------------------------------------------------------------------------

--- a/lib/Sisimai/Message/Email.pm
+++ b/lib/Sisimai/Message/Email.pm
@@ -395,6 +395,7 @@ sub parse {
         # Decode MIME-Encoded "Subject:" header
         $mailheader->{'subject'} = Sisimai::MIME->mimedecode([split(/[ ]/, $mailheader->{'subject'})]);
     }
+    $$bodystring =~ tr/\r//d;
     $$bodystring .= $EndOfEmail;
 
     my $haveloaded = {};

--- a/lib/Sisimai/Reason/Rejected.pm
+++ b/lib/Sisimai/Reason/Rejected.pm
@@ -43,6 +43,7 @@ sub match {
         'message rejected: email address is not verified',
         'mx records for ',
         'null sender is not allowed',
+        'recipient addresses rejected : access denied',
         'recipient not accepted. (batv: no tag',
         'returned mail not accepted here',
         'rfc 1035 violation: recursive cname records for',

--- a/lib/Sisimai/Rhost/ExchangeOnline.pm
+++ b/lib/Sisimai/Rhost/ExchangeOnline.pm
@@ -21,7 +21,7 @@ my $StatusList = {
     '5.3.3'  => [{ 'reason' => 'systemfull',  'string' => 'Unrecognized command' }],
     '5.3.4'  => [{ 'reason' => 'mesgtoobig',  'string' => 'Message too big for system' }],
     '5.3.5'  => [{ 'reason' => 'systemerror', 'string' => 'System incorrectly configured' }],
-    '5.4.1'  => [{ 'reason' => 'userunknown', 'string' => 'Recipient address rejected: Access denied' }],
+    '5.4.1'  => [{ 'reason' => 'rejected',    'string' => 'Recipient address rejected: Access denied' }],
     '5.4.14' => [{ 'reason' => 'networkerror','string' => 'Hop count exceeded' }],
     '5.5.2'  => [{ 'reason' => 'syntaxerror', 'string' => 'Send hello first' }],
     '5.5.3'  => [{ 'reason' => 'syntaxerror', 'string' => 'Too many recipients' }],
@@ -194,7 +194,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2018 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2019 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/t/302-rhost-exchangeonline.t
+++ b/t/302-rhost-exchangeonline.t
@@ -15,7 +15,7 @@ can_ok $PackageName, @{ $MethodNames->{'class'} };
 MAKE_TEST: {
     my $rs = {
         '01' => { 'status' => qr/\A5[.]7[.]606\z/, 'reason' => qr/blocked/ },
-        '02' => { 'status' => qr/\A5[.]4[.]1\z/,   'reason' => qr/userunknown/ },
+        '02' => { 'status' => qr/\A5[.]4[.]1\z/,   'reason' => qr/rejected/ },
         '03' => { 'status' => qr/\A5[.]1[.]10\z/,  'reason' => qr/userunknown/ },
     };
     is $PackageName->get, undef;

--- a/t/634-bite-email-postfix.t
+++ b/t/634-bite-email-postfix.t
@@ -25,7 +25,7 @@ my $isexpected = [
     { 'n' => '17', 's' => qr/\A5[.]4[.]4\z/,    'r' => qr/networkerror/, 'b' => qr/\A1\z/ },
     { 'n' => '28', 's' => qr/\A5[.]7[.]1\z/,    'r' => qr/policyviolation/, 'b' => qr/\A1\z/ },
     { 'n' => '29', 's' => qr/\A5[.]7[.]1\z/,    'r' => qr/policyviolation/, 'b' => qr/\A1\z/ },
-    { 'n' => '30', 's' => qr/\A5[.]4[.]1\z/,    'r' => qr/userunknown/,'b' => qr/\A0\z/ },
+    { 'n' => '30', 's' => qr/\A5[.]4[.]1\z/,    'r' => qr/rejected/,   'b' => qr/\A1\z/ },
     { 'n' => '31', 's' => qr/\A5[.]1[.]1\z/,    'r' => qr/userunknown/,'b' => qr/\A0\z/ },
     { 'n' => '32', 's' => qr/\A5[.]1[.]1\z/,    'r' => qr/userunknown/,'b' => qr/\A0\z/ },
     { 'n' => '33', 's' => qr/\A5[.]1[.]1\z/,    'r' => qr/userunknown/,'b' => qr/\A0\z/ },

--- a/xt/628-bite-email-mfilter.t
+++ b/xt/628-bite-email-mfilter.t
@@ -15,6 +15,7 @@ my $isexpected = [
     { 'n' => '01005', 'r' => qr/userunknown/ },
     { 'n' => '01006', 'r' => qr/filtered/    },
     { 'n' => '01007', 'r' => qr/filtered/    },
+    { 'n' => '01008', 'r' => qr/rejected/    },
 ];
 
 plan 'skip_all', sprintf("%s not found", $samplepath) unless -d $samplepath;

--- a/xt/634-bite-email-postfix.t
+++ b/xt/634-bite-email-postfix.t
@@ -220,6 +220,7 @@ my $isexpected = [
     { 'n' => '01210', 'r' => qr/blocked/        },
     { 'n' => '01211', 'r' => qr/userunknown/    },
     { 'n' => '01212', 'r' => qr/userunknown/    },
+    { 'n' => '01213', 'r' => qr/userunknown/    },
 ];
 
 plan 'skip_all', sprintf("%s not found", $samplepath) unless -d $samplepath;

--- a/xt/634-bite-email-postfix.t
+++ b/xt/634-bite-email-postfix.t
@@ -187,7 +187,7 @@ my $isexpected = [
     { 'n' => '01177', 'r' => qr/userunknown/    },
     { 'n' => '01178', 'r' => qr/blocked/        },
     { 'n' => '01179', 'r' => qr/norelaying/     },
-    { 'n' => '01180', 'r' => qr/userunknown/    },
+    { 'n' => '01180', 'r' => qr/rejected/       },
     { 'n' => '01181', 'r' => qr/userunknown/    },
     { 'n' => '01182', 'r' => qr/spamdetected/   },
     { 'n' => '01183', 'r' => qr/userunknown/    },


### PR DESCRIPTION
- https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/non-delivery-reports-in-exchange-online/fix-error-code-550-5-4-1-in-exchange-online
- Parser code to read bounce mails from m-FILTER at `Sisimai::Message::Email` has been improved. Thanks to Nomura Research Institute, Ltd.
- Status 5.4.1 from Exchange Online is classified into "rejected" reason.
