### PR TITLE
Make Sisimai::Lhost::* Faster take.2

### DIFF
--- a/lib/Sisimai.pm
+++ b/lib/Sisimai.pm
@@ -2,7 +2,7 @@ package Sisimai;
 use feature ':5.10';
 use strict;
 use warnings;
-use version; our $VERSION = version->declare('v4.25.5'); our $PATCHLV = 6;
+use version; our $VERSION = version->declare('v4.25.4'); our $PATCHLV = 6;
 
 sub version { return substr($VERSION->stringify, 1).($PATCHLV > 0 ? 'p'.$PATCHLV : '') }
 sub sysname { 'bouncehammer' }

--- a/lib/Sisimai/Lhost/Activehunter.pm
+++ b/lib/Sisimai/Lhost/Activehunter.pm
@@ -72,7 +72,7 @@ sub make {
             next unless $e =~ /\A[0-9A-Za-z]+/;
             next if length $v->{'diagnosis'};
             $v->{'diagnosis'} ||= $e;
-        } # End of error message part
+        }
     }
     return undef unless $recipients;
 

--- a/lib/Sisimai/Lhost/Amavis.pm
+++ b/lib/Sisimai/Lhost/Amavis.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['The message '],
-    'rfc822'  => ['Content-Type: text/rfc822-headers'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]text/rfc822-headers|m;
+my $StartingOf = { 'message' => ['The message '] };
 
 # https://www.amavis.org
 sub description { 'amavisd-new: https://www.amavis.org/' }
@@ -38,78 +36,56 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
+        next unless my $f = Sisimai::RFC1894->match($e);
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # $e matched with any field defined in RFC3464
+        next unless my $o = Sisimai::RFC1894->field($e);
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $o->[-1] eq 'addr' ) {
+            # Final-Recipient: rfc822; kijitora@example.jp
+            # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+            if( $o->[0] eq 'final-recipient' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                if( $v->{'recipient'} ) {
+                    # There are multiple recipient addresses in the message body.
+                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                    $v = $dscontents->[-1];
+                }
+                $v->{'recipient'} = $o->[2];
+                $recipients++;
+            } else {
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                $v->{'alias'} = $o->[2];
             }
-            push @$rfc822list, $e;
+        } elsif( $o->[-1] eq 'code' ) {
+            # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+            $v->{'spec'} = $o->[1];
+            $v->{'spec'} = 'SMTP' if $v->{'spec'} eq 'X-POSTFIX';
+            $v->{'diagnosis'} = $o->[2];
 
         } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-            next unless my $f = Sisimai::RFC1894->match($e);
+            # Other DSN fields defined in RFC3464
+            next unless exists $fieldtable->{ $o->[0] };
+            $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
 
-            # $e matched with any field defined in RFC3464
-            next unless my $o = Sisimai::RFC1894->field($e);
-            $v = $dscontents->[-1];
-
-            if( $o->[-1] eq 'addr' ) {
-                # Final-Recipient: rfc822; kijitora@example.jp
-                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                if( $o->[0] eq 'final-recipient' ) {
-                    # Final-Recipient: rfc822; kijitora@example.jp
-                    if( $v->{'recipient'} ) {
-                        # There are multiple recipient addresses in the message body.
-                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                        $v = $dscontents->[-1];
-                    }
-                    $v->{'recipient'} = $o->[2];
-                    $recipients++;
-                } else {
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    $v->{'alias'} = $o->[2];
-                }
-            } elsif( $o->[-1] eq 'code' ) {
-                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                $v->{'spec'} = $o->[1];
-                $v->{'spec'} = 'SMTP' if $v->{'spec'} eq 'X-POSTFIX';
-                $v->{'diagnosis'} = $o->[2];
-
-            } else {
-                # Other DSN fields defined in RFC3464
-                next unless exists $fieldtable->{ $o->[0] };
-                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                next unless $f == 1;
-                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
-            }
+            next unless $f == 1;
+            $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
         }
     }
     return undef unless $recipients;
@@ -121,7 +97,7 @@ sub make {
         $e->{'diagnosis'} ||= Sisimai::String->sweep($e->{'diagnosis'});
         $e->{'agent'}       = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -167,7 +143,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2019,2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/AmazonSES.pm
+++ b/lib/Sisimai/Lhost/AmazonSES.pm
@@ -45,11 +45,7 @@ sub make {
 
         # https://docs.aws.amazon.com/en_us/ses/latest/DeveloperGuide/notification-contents.html
         my $bouncetype = {
-            'Permanent' => {
-                'General'    => '',
-                'NoEmail'    => '',
-                'Suppressed' => '',
-            },
+            'Permanent' => { 'General' => '', 'NoEmail' => '', 'Suppressed' => '' },
             'Transient' => {
                 'General'            => '',
                 'MailboxFull'        => 'mailboxfull',

--- a/lib/Sisimai/Lhost/AmazonSES.pm
+++ b/lib/Sisimai/Lhost/AmazonSES.pm
@@ -296,7 +296,7 @@ sub make {
                 next unless index($p, 'Diagnostic-Code:') == 0;
                 next unless $e =~ /\A[ \t]+(.+)\z/;
                 $v->{'diagnosis'} .= ' '.$1;
-            } # End of message/delivery-status
+            }
         } continue {
             # Save the current line for the next loop
             $p = $e;

--- a/lib/Sisimai/Lhost/AmazonSES.pm
+++ b/lib/Sisimai/Lhost/AmazonSES.pm
@@ -6,9 +6,9 @@ use warnings;
 
 # https://aws.amazon.com/ses/
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr|^content-type:[ ]message/rfc822|m;
 my $StartingOf = {
     'message' => ['The following message to <', 'An error occurred while trying to deliver the mail '],
-    'rfc822'  => ['content-type: message/rfc822'],
 };
 my $MessagesOf = { 'expired' => ['Delivery expired'] };
 
@@ -205,10 +205,7 @@ sub make {
         }
         return undef unless $recipients;
 
-        for my $e ( @$dscontents ) {
-            $e->{'agent'} = __PACKAGE__->smtpagent;
-        }
-
+        map { $_->{'agent'} = __PACKAGE__->smtpagent } @$dscontents;
         if( exists $p->{'mail'}->{'headers'} ) {
             # "headersTruncated":false,
             # "headers":[ { ...
@@ -241,13 +238,12 @@ sub make {
         require Sisimai::RFC1894;
         my $fieldtable = Sisimai::RFC1894->FIELDTABLE;
         my $permessage = {};    # (Hash) Store values of each Per-Message field
-        my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-        my $blanklines = 0;     # (Integer) The number of blank lines
         my $readcursor = 0;     # (Integer) Points the current cursor position
+        my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
         my $v = undef;
         my $p = '';
 
-        for my $e ( split("\n", $$mbody) ) {
+        for my $e ( split("\n", $emailsteak->[0]) ) {
             # Read each line between the start of the message and the start of rfc822 part.
             unless( $readcursor ) {
                 # Beginning of the bounce message or message/delivery-status part
@@ -257,69 +253,49 @@ sub make {
                     next;
                 }
             }
+            next unless $readcursor & $Indicators->{'deliverystatus'};
+            next unless length $e;
 
-            unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-                # Beginning of the original message part(message/rfc822)
-                if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                    $readcursor |= $Indicators->{'message-rfc822'};
-                    next;
-                }
-            }
+            if( my $f = Sisimai::RFC1894->match($e) ) {
+                # $e matched with any field defined in RFC3464
+                next unless my $o = Sisimai::RFC1894->field($e);
+                $v = $dscontents->[-1];
 
-            if( $readcursor & $Indicators->{'message-rfc822'} ) {
-                # message/rfc822 or text/rfc822-headers part
-                unless( length $e ) {
-                    last if ++$blanklines > 1;
-                    next;
-                }
-                push @$rfc822list, $e;
-
-            } else {
-                # message/delivery-status part
-                next unless $readcursor & $Indicators->{'deliverystatus'};
-                next unless length $e;
-
-                if( my $f = Sisimai::RFC1894->match($e) ) {
-                    # $e matched with any field defined in RFC3464
-                    next unless my $o = Sisimai::RFC1894->field($e);
-                    $v = $dscontents->[-1];
-
-                    if( $o->[-1] eq 'addr' ) {
+                if( $o->[-1] eq 'addr' ) {
+                    # Final-Recipient: rfc822; kijitora@example.jp
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    if( $o->[0] eq 'final-recipient' ) {
                         # Final-Recipient: rfc822; kijitora@example.jp
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        if( $o->[0] eq 'final-recipient' ) {
-                            # Final-Recipient: rfc822; kijitora@example.jp
-                            if( $v->{'recipient'} ) {
-                                # There are multiple recipient addresses in the message body.
-                                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                                $v = $dscontents->[-1];
-                            }
-                            $v->{'recipient'} = $o->[2];
-                            $recipients++;
-
-                        } else {
-                            # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                            $v->{'alias'} = $o->[2];
+                        if( $v->{'recipient'} ) {
+                            # There are multiple recipient addresses in the message body.
+                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                            $v = $dscontents->[-1];
                         }
-                    } elsif( $o->[-1] eq 'code' ) {
-                        # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                        $v->{'spec'} = $o->[1];
-                        $v->{'diagnosis'} = $o->[2];
+                        $v->{'recipient'} = $o->[2];
+                        $recipients++;
 
                     } else {
-                        # Other DSN fields defined in RFC3464
-                        next unless exists $fieldtable->{ $o->[0] };
-                        $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                        next unless $f == 1;
-                        $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                        $v->{'alias'} = $o->[2];
                     }
+                } elsif( $o->[-1] eq 'code' ) {
+                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                    $v->{'spec'} = $o->[1];
+                    $v->{'diagnosis'} = $o->[2];
+
                 } else {
-                    # Continued line of the value of Diagnostic-Code field
-                    next unless index($p, 'Diagnostic-Code:') == 0;
-                    next unless $e =~ /\A[ \t]+(.+)\z/;
-                    $v->{'diagnosis'} .= ' '.$1;
+                    # Other DSN fields defined in RFC3464
+                    next unless exists $fieldtable->{ $o->[0] };
+                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                    next unless $f == 1;
+                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
                 }
+            } else {
+                # Continued line of the value of Diagnostic-Code field
+                next unless index($p, 'Diagnostic-Code:') == 0;
+                next unless $e =~ /\A[ \t]+(.+)\z/;
+                $v->{'diagnosis'} .= ' '.$1;
             } # End of message/delivery-status
         } continue {
             # Save the current line for the next loop
@@ -351,7 +327,7 @@ sub make {
                 last;
             }
         }
-        return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+        return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
     }
 }
 
@@ -404,7 +380,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/AmazonWorkMail.pm
+++ b/lib/Sisimai/Lhost/AmazonWorkMail.pm
@@ -6,10 +6,8 @@ use warnings;
 
 # https://aws.amazon.com/workmail/
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['Technical report:'],
-    'rfc822'  => ['content-type: message/rfc822'],
-};
+my $ReBackbone = qr|^content-type:[ ]message/rfc822|m;
+my $StartingOf = { 'message' => ['Technical report:'] };
 
 # X-Mailer: Amazon WorkMail
 # X-Original-Mailer: Amazon WorkMail
@@ -50,86 +48,64 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( $e eq $StartingOf->{'message'}->[0] ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( $e eq $StartingOf->{'rfc822'}->[0] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 or text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
-            }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
 
-            # <!DOCTYPE HTML><html>
-            # <head>
-            # <meta name="Generator" content="Amazon WorkMail v3.0-2023.77">
-            # <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-            last if index($e, '<!DOCTYPE HTML><html>') == 0;
+            } else {
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            }
         } # End of message/delivery-status
+
+        # <!DOCTYPE HTML><html>
+        # <head>
+        # <meta name="Generator" content="Amazon WorkMail v3.0-2023.77">
+        # <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        last if index($e, '<!DOCTYPE HTML><html>') == 0;
     }
     return undef unless $recipients;
 
@@ -153,7 +129,7 @@ sub make {
         $e->{'reason'}  ||= Sisimai::SMTP::Status->name($e->{'status'}) || '';
         $e->{'agent'}     = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -199,7 +175,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/AmazonWorkMail.pm
+++ b/lib/Sisimai/Lhost/AmazonWorkMail.pm
@@ -99,7 +99,7 @@ sub make {
                 next unless $f == 1;
                 $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
-        } # End of message/delivery-status
+        }
 
         # <!DOCTYPE HTML><html>
         # <head>

--- a/lib/Sisimai/Lhost/Aol.pm
+++ b/lib/Sisimai/Lhost/Aol.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['Content-Type: message/delivery-status'],
-    'rfc822'  => ['Content-Type: message/rfc822'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
+my $StartingOf = { 'message' => ['Content-Type: message/delivery-status'] };
 my $MessagesOf = {
     'hostunknown' => ['Host or domain name not found'],
     'notaccept'   => ['type=MX: Malformed or unexpected name server reply'],
@@ -52,85 +50,63 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 or text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
             } else {
-                # Continued line of the value of Diagnostic-Code field
-                next unless index($p, 'Diagnostic-Code:') == 0;
-                next unless $e =~ /\A[ \t]+(.+)\z/;
-                $v->{'diagnosis'} .= ' '.$1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
+        } else {
+            # Continued line of the value of Diagnostic-Code field
+            next unless index($p, 'Diagnostic-Code:') == 0;
+            next unless $e =~ /\A[ \t]+(.+)\z/;
+            $v->{'diagnosis'} .= ' '.$1;
         } # End of message/delivery-status
     } continue {
         # Save the current line for the next loop
@@ -154,7 +130,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -200,7 +176,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Aol.pm
+++ b/lib/Sisimai/Lhost/Aol.pm
@@ -107,7 +107,7 @@ sub make {
             next unless index($p, 'Diagnostic-Code:') == 0;
             next unless $e =~ /\A[ \t]+(.+)\z/;
             $v->{'diagnosis'} .= ' '.$1;
-        } # End of message/delivery-status
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;

--- a/lib/Sisimai/Lhost/ApacheJames.pm
+++ b/lib/Sisimai/Lhost/ApacheJames.pm
@@ -113,7 +113,7 @@ sub make {
                 $v->{'diagnosis'} = $e if $e eq $StartingOf->{'error'}->[0];
                 $v->{'diagnosis'} .= ' '.$e unless $gotmessage;
             }
-        } # End of error message part
+        }
     }
     return undef unless $recipients;
 

--- a/lib/Sisimai/Lhost/ApacheJames.pm
+++ b/lib/Sisimai/Lhost/ApacheJames.pm
@@ -5,12 +5,12 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
 my $StartingOf = {
     # apache-james-2.3.2/src/java/org/apache/james/transport/mailets/
     #   AbstractNotify.java|124:  out.println("Error message below:");
     #   AbstractNotify.java|128:  out.println("Message details:");
     'message' => [''],
-    'rfc822'  => ['Content-Type: message/rfc822'],
     'error'   => ['Error message below:'],
 };
 
@@ -42,8 +42,7 @@ sub make {
     return undef unless $match;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $diagnostic = '';    # (String) Alternative diagnostic message
@@ -51,105 +50,82 @@ sub make {
     my $gotmessage = 0;     # (Integer) Flag for error message
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # Message details:
+        #   Subject: Nyaaan
+        #   Sent date: Thu Apr 29 01:20:50 JST 2015
+        #   MAIL FROM: shironeko@example.jp
+        #   RCPT TO: kijitora@example.org
+        #   From: Neko <shironeko@example.jp>
+        #   To: kijitora@example.org
+        #   Size (in bytes): 1024
+        #   Number of lines: 64
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A[ ][ ]RCPT[ ]TO:[ ]([^ ]+[@][^ ]+)\z/ ) {
+            #   RCPT TO: kijitora@example.org
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+            $v->{'recipient'} = $1;
+            $recipients++;
+
+        } elsif( $e =~ /\A[ ][ ]Sent[ ]date:[ ](.+)\z/ ) {
+            #   Sent date: Thu Apr 29 01:20:50 JST 2015
+            $v->{'date'} = $1;
+
+        } elsif( $e =~ /\A[ ][ ]Subject:[ ](.+)\z/ ) {
+            #   Subject: Nyaaan
+            $subjecttxt = $1;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
+            next if $gotmessage == 1;
 
-            # Message details:
-            #   Subject: Nyaaan
-            #   Sent date: Thu Apr 29 01:20:50 JST 2015
-            #   MAIL FROM: shironeko@example.jp
-            #   RCPT TO: kijitora@example.org
-            #   From: Neko <shironeko@example.jp>
-            #   To: kijitora@example.org
-            #   Size (in bytes): 1024
-            #   Number of lines: 64
-            $v = $dscontents->[-1];
+            if( $v->{'diagnosis'} ) {
+                # Get an error message text
+                if( $e eq 'Message details:' ) {
+                    # Message details:
+                    #   Subject: nyaan
+                    #   ...
+                    $gotmessage = 1;
 
-            if( $e =~ /\A[ ][ ]RCPT[ ]TO:[ ]([^ ]+[@][^ ]+)\z/ ) {
-                #   RCPT TO: kijitora@example.org
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $recipients++;
-
-            } elsif( $e =~ /\A[ ][ ]Sent[ ]date:[ ](.+)\z/ ) {
-                #   Sent date: Thu Apr 29 01:20:50 JST 2015
-                $v->{'date'} = $1;
-
-            } elsif( $e =~ /\A[ ][ ]Subject:[ ](.+)\z/ ) {
-                #   Subject: Nyaaan
-                $subjecttxt = $1;
-
-            } else {
-                next if $gotmessage == 1;
-
-                if( $v->{'diagnosis'} ) {
-                    # Get an error message text
-                    if( $e eq 'Message details:' ) {
-                        # Message details:
-                        #   Subject: nyaan
-                        #   ...
-                        $gotmessage = 1;
-
-                    } else {
-                        # Append error message text like the followng:
-                        #   Error message below:
-                        #   550 - Requested action not taken: no such user here
-                        $v->{'diagnosis'} .= ' '.$e;
-                    }
                 } else {
-                    # Error message below:
-                    # 550 - Requested action not taken: no such user here
-                    $v->{'diagnosis'} = $e if $e eq $StartingOf->{'error'}->[0];
-                    $v->{'diagnosis'} .= ' '.$e unless $gotmessage;
+                    # Append error message text like the followng:
+                    #   Error message below:
+                    #   550 - Requested action not taken: no such user here
+                    $v->{'diagnosis'} .= ' '.$e;
                 }
+            } else {
+                # Error message below:
+                # 550 - Requested action not taken: no such user here
+                $v->{'diagnosis'} = $e if $e eq $StartingOf->{'error'}->[0];
+                $v->{'diagnosis'} .= ' '.$e unless $gotmessage;
             }
         } # End of error message part
     }
     return undef unless $recipients;
 
-    unless( grep { index($_, 'Subject:') == 0 } @$rfc822list ) {
-        # Set the value of $subjecttxt as a Subject if there is no original
-        # message in the bounce mail.
-        push @$rfc822list, 'Subject: '.$subjecttxt;
-    }
+    # Set the value of $subjecttxt as a Subject if there is no original message
+    # in the bounce mail.
+    $emailsteak->[1] .= sprintf("Subject: %s\n", $subjecttxt) unless $emailsteak->[1] =~ /^Subject:/m;
 
     for my $e ( @$dscontents ) {
         $e->{'agent'}     = __PACKAGE__->smtpagent;
         $e->{'diagnosis'} = Sisimai::String->sweep($e->{'diagnosis'} || $diagnostic);
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -195,7 +171,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Bigfoot.pm
+++ b/lib/Sisimai/Lhost/Bigfoot.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = { 'rfc822'  => ['Content-Type: message/partial'] };
+my $ReBackbone = qr|^Content-Type:[ ]message/partial|m;
 my $MarkingsOf = { 'message' => qr/\A[ \t]+[-]+[ \t]*Transcript of session follows/ };
 
 sub description { 'Bigfoot: http://www.bigfoot.com' }
@@ -37,8 +37,7 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
@@ -46,94 +45,73 @@ sub make {
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( $e =~ $MarkingsOf->{'message'} ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if $e =~ $MarkingsOf->{'message'};
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 or text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
+                }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
 
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            } else {
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            }
+        } else {
+            # The line does not begin with a DSN field defined in RFC3464
+            if( substr($e, 0, 1) ne ' ' ) {
+                #    ----- Transcript of session follows -----
+                # >>> RCPT TO:<destinaion@example.net>
+                # <<< 553 Invalid recipient destinaion@example.net (Mode: normal)
+                if( $e =~ /\A[>]{3}[ ]+([A-Z]{4})[ ]?/ ) {
+                    # >>> DATA
+                    $commandtxt = $1;
+
+                } elsif( $e =~ /\A[<]{3}[ ]+(.+)\z/ ) {
+                    # <<< Response
+                    $esmtpreply = $1;
                 }
             } else {
-                # The line does not begin with a DSN field defined in RFC3464
-                if( substr($e, 0, 1) ne ' ' ) {
-                    #    ----- Transcript of session follows -----
-                    # >>> RCPT TO:<destinaion@example.net>
-                    # <<< 553 Invalid recipient destinaion@example.net (Mode: normal)
-                    if( $e =~ /\A[>]{3}[ ]+([A-Z]{4})[ ]?/ ) {
-                        # >>> DATA
-                        $commandtxt = $1;
-
-                    } elsif( $e =~ /\A[<]{3}[ ]+(.+)\z/ ) {
-                        # <<< Response
-                        $esmtpreply = $1;
-                    }
-                } else {
-                    # Continued line of the value of Diagnostic-Code field
-                    next unless index($p, 'Diagnostic-Code:') == 0;
-                    next unless $e =~ /\A[ \t]+(.+)\z/;
-                    $v->{'diagnosis'} .= ' '.$1;
-                }
+                # Continued line of the value of Diagnostic-Code field
+                next unless index($p, 'Diagnostic-Code:') == 0;
+                next unless $e =~ /\A[ \t]+(.+)\z/;
+                $v->{'diagnosis'} .= ' '.$1;
             }
-        } # End of message/delivery-status
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -150,7 +128,7 @@ sub make {
         $e->{'command'} ||= 'EHLO' if $esmtpreply;
         $e->{'agent'}     = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -196,7 +174,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Biglobe.pm
+++ b/lib/Sisimai/Lhost/Biglobe.pm
@@ -5,9 +5,9 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
 my $StartingOf = {
     'message' => ['   ----- The following addresses had delivery problems -----'],
-    'rfc822'  => ['Content-Type: message/rfc822'],
     'error'   => ['   ----- Non-delivered information -----'],
 };
 my $MessagesOf = {
@@ -37,78 +37,56 @@ sub make {
     return undef unless index($mhead->{'subject'}, 'Returned mail:') == 0;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # This is a MIME-encapsulated message.
+        #
+        # ----_Biglobe000000/00000.biglobe.ne.jp
+        # Content-Type: text/plain; charset="iso-2022-jp"
+        #
+        #    ----- The following addresses had delivery problems -----
+        # ********@***.biglobe.ne.jp
+        #
+        #    ----- Non-delivered information -----
+        # The number of messages in recipient's mailbox exceeded the local limit.
+        #
+        # ----_Biglobe000000/00000.biglobe.ne.jp
+        # Content-Type: message/rfc822
+        #
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # This is a MIME-encapsulated message.
-            #
-            # ----_Biglobe000000/00000.biglobe.ne.jp
-            # Content-Type: text/plain; charset="iso-2022-jp"
-            #
+        if( $e =~ /\A([^ ]+[@][^ ]+)\z/ ) {
             #    ----- The following addresses had delivery problems -----
             # ********@***.biglobe.ne.jp
-            #
-            #    ----- Non-delivered information -----
-            # The number of messages in recipient's mailbox exceeded the local limit.
-            #
-            # ----_Biglobe000000/00000.biglobe.ne.jp
-            # Content-Type: message/rfc822
-            #
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A([^ ]+[@][^ ]+)\z/ ) {
-                #    ----- The following addresses had delivery problems -----
-                # ********@***.biglobe.ne.jp
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-
-                my $r = Sisimai::Address->s3s4($1);
-                next unless Sisimai::RFC5322->is_emailaddress($r);
-                $v->{'recipient'} = $r;
-                $recipients++;
-
-            } else {
-                next if $e =~ /\A[^\w]/;
-                $v->{'diagnosis'} .= $e.' ';
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-        } # End of error message part
+
+            my $r = Sisimai::Address->s3s4($1);
+            next unless Sisimai::RFC5322->is_emailaddress($r);
+            $v->{'recipient'} = $r;
+            $recipients++;
+
+        } else {
+            next if $e =~ /\A[^\w]/;
+            $v->{'diagnosis'} .= $e.' ';
+        }
     }
     return undef unless $recipients;
 
@@ -123,7 +101,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -169,7 +147,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Courier.pm
+++ b/lib/Sisimai/Lhost/Courier.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $ReBackbone = qr%^Content-Type:[ ](?:message/rfc822|text/rfc822-headers)%m;
+my $ReBackbone = qr<^Content-Type:[ ](?:message/rfc822|text/rfc822-headers)>m;
 my $StartingOf = {
     # https://www.courier-mta.org/courierdsn.html
     # courier/module.dsn/dsn*.txt

--- a/lib/Sisimai/Lhost/Courier.pm
+++ b/lib/Sisimai/Lhost/Courier.pm
@@ -5,11 +5,11 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr%^Content-Type:[ ](?:message/rfc822|text/rfc822-headers)%m;
 my $StartingOf = {
     # https://www.courier-mta.org/courierdsn.html
     # courier/module.dsn/dsn*.txt
     'message' => ['DELAYS IN DELIVERING YOUR MESSAGE', 'UNDELIVERABLE MAIL'],
-    'rfc822'  => ['Content-Type: message/rfc822', 'Content-Type: text/rfc822-headers'],
 };
 
 my $MessagesOf = {
@@ -54,16 +54,16 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
             if( rindex($e, $StartingOf->{'message'}->[0]) > -1 ||
@@ -72,97 +72,76 @@ sub make {
                 next;
             }
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ||
-                index($e, $StartingOf->{'rfc822'}->[1]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
+
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
+                    # Final-Recipient: rfc822; kijitora@example.jp
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
+                    }
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
+
+                } else {
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
+                }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
+            } else {
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            }
+        } else {
+            # The line does not begin with a DSN field defined in RFC3464
+            #
+            # This is a delivery status notification from marutamachi.example.org,
+            # running the Courier mail server, version 0.65.2.
+            #
+            # The original message was received on Sat, 11 Dec 2010 12:19:57 +0900
+            # from [127.0.0.1] (c10920.example.com [192.0.2.20])
+            #
+            # ---------------------------------------------------------------------------
+            #
+            #                           UNDELIVERABLE MAIL
+            #
+            # Your message to the following recipients cannot be delivered:
+            #
+            # <kijitora@example.co.jp>:
+            #    mx.example.co.jp [74.207.247.95]:
+            # >>> RCPT TO:<kijitora@example.co.jp>
+            # <<< 550 5.1.1 <kijitora@example.co.jp>... User Unknown
+            #
+            # ---------------------------------------------------------------------------
+            if( $e =~ /\A[>]{3}[ ]+([A-Z]{4})[ ]?/ ) {
+                # >>> DATA
+                $commandtxt ||= $1;
+
+            } else {
+                # Continued line of the value of Diagnostic-Code field
+                next unless index($p, 'Diagnostic-Code:') == 0;
+                next unless $e =~ /\A[ \t]+(.+)\z/;
+                $v->{'diagnosis'} .= ' '.$1;
             }
         }
-
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 or text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
-                    # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
-                    }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
-
-                } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
-                }
-            } else {
-                # The line does not begin with a DSN field defined in RFC3464
-                #
-                # This is a delivery status notification from marutamachi.example.org,
-                # running the Courier mail server, version 0.65.2.
-                #
-                # The original message was received on Sat, 11 Dec 2010 12:19:57 +0900
-                # from [127.0.0.1] (c10920.example.com [192.0.2.20])
-                #
-                # ---------------------------------------------------------------------------
-                #
-                #                           UNDELIVERABLE MAIL
-                #
-                # Your message to the following recipients cannot be delivered:
-                #
-                # <kijitora@example.co.jp>:
-                #    mx.example.co.jp [74.207.247.95]:
-                # >>> RCPT TO:<kijitora@example.co.jp>
-                # <<< 550 5.1.1 <kijitora@example.co.jp>... User Unknown
-                #
-                # ---------------------------------------------------------------------------
-                if( $e =~ /\A[>]{3}[ ]+([A-Z]{4})[ ]?/ ) {
-                    # >>> DATA
-                    $commandtxt ||= $1;
-
-                } else {
-                    # Continued line of the value of Diagnostic-Code field
-                    next unless index($p, 'Diagnostic-Code:') == 0;
-                    next unless $e =~ /\A[ \t]+(.+)\z/;
-                    $v->{'diagnosis'} .= ' '.$1;
-                }
-            }
-        } # End of message/delivery-status
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -183,7 +162,7 @@ sub make {
         $e->{'agent'}     = __PACKAGE__->smtpagent;
         $e->{'command'} ||= $commandtxt || '';
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -229,7 +208,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Domino.pm
+++ b/lib/Sisimai/Lhost/Domino.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['Your message'],
-    'rfc822'  => ['Content-Type: message/delivery-status'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]message/delivery-status|m;
+my $StartingOf = { 'message' => ['Your message'] };
 my $MessagesOf = {
     'userunknown' => [
         'not listed in Domino Directory',
@@ -39,89 +37,66 @@ sub make {
     return undef unless index($mhead->{'subject'}, 'DELIVERY FAILURE:') == 0;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $subjecttxt = '';    # (String) The value of Subject:
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
+        unless( $readcursor ) {
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
+        }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
         next unless length $e;
 
-        unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
+        # Your message
+        #
+        #   Subject: Test Bounce
+        #
+        # was not delivered to:
+        #
+        #   kijitora@example.net
+        #
+        # because:
+        #
+        #   User some.name (kijitora@example.net) not listed in Domino Directory
+        #
+        $v = $dscontents->[-1];
+        if( $e eq 'was not delivered to:' ) {
+            # was not delivered to:
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-        }
+            $v->{'recipient'} ||= $e;
+            $recipients++;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        } elsif( $e =~ /\A[ ][ ]([^ ]+[@][^ ]+)\z/ ) {
+            # Continued from the line "was not delivered to:"
+            #   kijitora@example.net
+            $v->{'recipient'} = Sisimai::Address->s3s4($1);
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
+        } elsif( $e eq 'because:' ) {
+            # because:
+            $v->{'diagnosis'} = $e;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-
-            # Your message
-            #
-            #   Subject: Test Bounce
-            #
-            # was not delivered to:
-            #
-            #   kijitora@example.net
-            #
-            # because:
-            #
-            #   User some.name (kijitora@example.net) not listed in Domino Directory
-            #
-            $v = $dscontents->[-1];
-            if( $e eq 'was not delivered to:' ) {
-                # was not delivered to:
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} ||= $e;
-                $recipients++;
-
-            } elsif( $e =~ /\A[ ][ ]([^ ]+[@][^ ]+)\z/ ) {
-                # Continued from the line "was not delivered to:"
-                #   kijitora@example.net
-                $v->{'recipient'} = Sisimai::Address->s3s4($1);
-
-            } elsif( $e eq 'because:' ) {
-                # because:
+            if( exists $v->{'diagnosis'} && $v->{'diagnosis'} eq 'because:' ) {
+                # Error message, continued from the line "because:"
                 $v->{'diagnosis'} = $e;
 
-            } else {
-                if( exists $v->{'diagnosis'} && $v->{'diagnosis'} eq 'because:' ) {
-                    # Error message, continued from the line "because:"
-                    $v->{'diagnosis'} = $e;
-
-                } elsif( $e =~ /\A[ ][ ]Subject: (.+)\z/ ) {
-                    #   Subject: Nyaa
-                    $subjecttxt = $1;
-                }
+            } elsif( $e =~ /\A[ ][ ]Subject: (.+)\z/ ) {
+                #   Subject: Nyaa
+                $subjecttxt = $1;
             }
-        } # End of if: rfc822
+        }
     }
     return undef unless $recipients;
 
@@ -139,12 +114,11 @@ sub make {
         }
     }
 
-    unless( grep { index($_, 'Subject:') == 0 } @$rfc822list ) {
-        # Set the value of $subjecttxt as a Subject if there is no original
-        # message in the bounce mail.
-        push @$rfc822list, 'Subject: '.$subjecttxt;
-    }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    # Set the value of $subjecttxt as a Subject if there is no original
+    # message in the bounce mail.
+    $emailsteak->[1] .= sprintf("Subject: %s\n", $subjecttxt) unless $emailsteak->[1] =~ /^Subject:/m;
+
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -190,7 +164,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/EZweb.pm
+++ b/lib/Sisimai/Lhost/EZweb.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr<^(?:[-]{50}|Content-Type:[ ]*message/rfc822)>m;
 my $MarkingsOf = {
     'message' => qr{\A(?:
          The[ ]user[(]s[)][ ]
@@ -13,7 +14,6 @@ my $MarkingsOf = {
         |[<][^ ]+[@][^ ]+[>]\z
         )
     }x,
-    'rfc822'   => qr#\A(?:[-]{50}|Content-Type:[ ]*message/rfc822)#,
     'boundary' => qr/\A__SISIMAI_PSEUDO_BOUNDARY__\z/,
 };
 my $ReFailures = {
@@ -74,8 +74,7 @@ sub make {
     require Sisimai::RFC1894;
     my $fieldtable = Sisimai::RFC1894->FIELDTABLE;
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
@@ -88,83 +87,64 @@ sub make {
     }
     my @rxmessages; map { push @rxmessages, @{ $ReFailures->{ $_ } } } (keys %$ReFailures);
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
+            # Beginning of the bounce message or message/delivery-status part
             $readcursor |= $Indicators->{'deliverystatus'} if $e =~ $MarkingsOf->{'message'};
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e =~ $MarkingsOf->{'rfc822'} || $e =~ $MarkingsOf->{'boundary'} ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # The user(s) account is disabled.
+        #
+        # <***@ezweb.ne.jp>: 550 user unknown (in reply to RCPT TO command)
+        #
+        #  -- OR --
+        # Each of the following recipients was rejected by a remote
+        # mail server.
+        #
+        #    Recipient: <******@ezweb.ne.jp>
+        #    >>> RCPT TO:<******@ezweb.ne.jp>
+        #    <<< 550 <******@ezweb.ne.jp>: User unknown
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A[<]([^ ]+[@][^ ]+)[>]\z/ ||
+            $e =~ /\A[<]([^ ]+[@][^ ]+)[>]:?(.*)\z/ ||
+            $e =~ /\A[ \t]+Recipient: [<]([^ ]+[@][^ ]+)[>]/ ) {
+
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+
+            my $r = Sisimai::Address->s3s4($1);
+            $v->{'recipient'} = $r;
+            $recipients++;
+
+        } elsif( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            next unless exists $fieldtable->{ $o->[0] };
+            $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # The user(s) account is disabled.
-            #
-            # <***@ezweb.ne.jp>: 550 user unknown (in reply to RCPT TO command)
-            #
-            #  -- OR --
-            # Each of the following recipients was rejected by a remote
-            # mail server.
-            #
-            #    Recipient: <******@ezweb.ne.jp>
-            #    >>> RCPT TO:<******@ezweb.ne.jp>
-            #    <<< 550 <******@ezweb.ne.jp>: User unknown
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A[<]([^ ]+[@][^ ]+)[>]\z/ ||
-                $e =~ /\A[<]([^ ]+[@][^ ]+)[>]:?(.*)\z/ ||
-                $e =~ /\A[ \t]+Recipient: [<]([^ ]+[@][^ ]+)[>]/ ) {
-
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-
-                my $r = Sisimai::Address->s3s4($1);
-                $v->{'recipient'} = $r;
-                $recipients++;
-
-            } elsif( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                next unless exists $fieldtable->{ $o->[0] };
-                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            # The line does not begin with a DSN field defined in RFC3464
+            next if Sisimai::String->is_8bit(\$e);
+            if( $e =~ /\A[ \t]+[>]{3}[ \t]+([A-Z]{4})/ ) {
+                #    >>> RCPT TO:<******@ezweb.ne.jp>
+                $v->{'command'} = $1;
 
             } else {
-                # The line does not begin with a DSN field defined in RFC3464
-                next if Sisimai::String->is_8bit(\$e);
-                if( $e =~ /\A[ \t]+[>]{3}[ \t]+([A-Z]{4})/ ) {
-                    #    >>> RCPT TO:<******@ezweb.ne.jp>
-                    $v->{'command'} = $1;
-
+                # Check error message
+                if( grep { $e =~ $_ } @rxmessages ) {
+                    # Check with regular expressions of each error
+                    $v->{'diagnosis'} .= ' '.$e;
                 } else {
-                    # Check error message
-                    if( grep { $e =~ $_ } @rxmessages ) {
-                        # Check with regular expressions of each error
-                        $v->{'diagnosis'} .= ' '.$e;
-                    } else {
-                        # >>> 550
-                        $v->{'alterrors'} .= ' '.$e;
-                    }
+                    # >>> 550
+                    $v->{'alterrors'} .= ' '.$e;
                 }
             }
         } # End of error message part
@@ -213,7 +193,7 @@ sub make {
         next if $e->{'recipient'} =~ /[@](?:ezweb[.]ne[.]jp|au[.]com)\z/;
         $e->{'reason'} = 'userunknown';
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -258,7 +238,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/EinsUndEins.pm
+++ b/lib/Sisimai/Lhost/EinsUndEins.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $ReBackbone = qr|^---[ ]The[ ]header[ ]of[ ]the[ ]original[ ]message[ ]is[ ]following[.]---|m;
+my $ReBackbone = qr|^---[ ]The[ ]header[ ]of[ ]the[ ]original[ ]message[ ]is[ ]following[.][ ]---|m;
 my $StartingOf = {
     'message' => ['This message was created automatically by mail delivery software'],
     'error'   => ['For the following reason:'],

--- a/lib/Sisimai/Lhost/EinsUndEins.pm
+++ b/lib/Sisimai/Lhost/EinsUndEins.pm
@@ -5,9 +5,9 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr|^---[ ]The[ ]header[ ]of[ ]the[ ]original[ ]message[ ]is[ ]following[.]---|m;
 my $StartingOf = {
     'message' => ['This message was created automatically by mail delivery software'],
-    'rfc822'  => ['--- The header of the original message is following'],
     'error'   => ['For the following reason:'],
 };
 my $MessagesOf = { 'mesgtoobig' => ['Mail size limit exceeded'] };
@@ -35,80 +35,58 @@ sub make {
     return undef unless $mhead->{'subject'} eq 'Mail delivery failed: returning message to sender';
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # The following address failed:
+        #
+        # general@example.eu
+        #
+        # For the following reason:
+        #
+        # Mail size limit exceeded. For explanation visit
+        # http://postmaster.1and1.com/en/error-messages?ip=%1s
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A([^ ]+[@][^ ]+)\z/ ) {
+            # general@example.eu
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+            $v->{'recipient'} = $1;
+            $recipients++;
+
+        } elsif( index($e, $StartingOf->{'error'}->[0]) == 0 ) {
+            # For the following reason:
+            $v->{'diagnosis'} = $e;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # The following address failed:
-            #
-            # general@example.eu
-            #
-            # For the following reason:
-            #
-            # Mail size limit exceeded. For explanation visit
-            # http://postmaster.1and1.com/en/error-messages?ip=%1s
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A([^ ]+[@][^ ]+)\z/ ) {
-                # general@example.eu
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $recipients++;
-
-            } elsif( index($e, $StartingOf->{'error'}->[0]) == 0 ) {
-                # For the following reason:
-                $v->{'diagnosis'} = $e;
+            if( length $v->{'diagnosis'} ) {
+                # Get error message and append the error message strings
+                $v->{'diagnosis'} .= ' '.$e;
 
             } else {
-                if( length $v->{'diagnosis'} ) {
-                    # Get error message and append the error message strings
-                    $v->{'diagnosis'} .= ' '.$e;
-
-                } else {
-                    # OR the following format:
-                    #   neko@example.fr:
-                    #   SMTP error from remote server for TEXT command, host: ...
-                    $v->{'alterrors'} .= ' '.$e;
-                }
+                # OR the following format:
+                #   neko@example.fr:
+                #   SMTP error from remote server for TEXT command, host: ...
+                $v->{'alterrors'} .= ' '.$e;
             }
-        } # End of error message part
+        }
     }
     return undef unless $recipients;
 
@@ -137,7 +115,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -183,7 +161,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Exim.pm
+++ b/lib/Sisimai/Lhost/Exim.pm
@@ -165,12 +165,10 @@ sub make {
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
     my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
+    my $nextcursor = 0;
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $localhost0 = '';    # (String) Local MTA
     my $boundary00 = '';    # (String) Boundary string
-    my $havepassed = {
-        'deliverystatus' => 0
-    };
     my $v = undef;
 
     if( $mhead->{'content-type'} ) {
@@ -278,9 +276,9 @@ sub make {
                         }
                     } else {
                         # Error message ?
-                        next if $havepassed->{'deliverystatus'};
+                        next if $nextcursor;
                         # Content-type: message/delivery-status
-                        $havepassed->{'deliverystatus'} = 1 if index($e, $StartingOf->{'deliverystatus'}) == 0;
+                        $nextcursor = 1 if index($e, $StartingOf->{'deliverystatus'}) == 0;
                         $v->{'alterrors'} .= $e.' ' if index($e, ' ') == 0;
                     }
                 } else {

--- a/lib/Sisimai/Lhost/Exim.pm
+++ b/lib/Sisimai/Lhost/Exim.pm
@@ -5,6 +5,15 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr{^(?:
+    # deliver.c:6423|          if (bounce_return_body) fprintf(f,
+    # deliver.c:6424|"------ This is a copy of the message, including all the headers. ------\n");
+    # deliver.c:6425|          else fprintf(f,
+    # deliver.c:6426|"------ This is a copy of the message's headers. ------\n");
+     [-]+[ ]This[ ]is[ ]a[ ]copy[ ]of[ ](?:the|your)[ ]message.+headers[.][ ][-]+
+    |Content-Type:[ ]*message/rfc822
+    )
+}mx;
 my $StartingOf = {
     'deliverystatus' => ['Content-type: message/delivery-status'],
     'endof'          => ['__END_OF_EMAIL_MESSAGE__'],
@@ -27,11 +36,6 @@ my $MarkingsOf = {
     # deliver.c:6304|"could not be delivered to one or more of its recipients. The following\n"
     # deliver.c:6305|"address(es) failed:\n", sender_address);
     # deliver.c:6306|          }
-    #
-    # deliver.c:6423|          if (bounce_return_body) fprintf(f,
-    # deliver.c:6424|"------ This is a copy of the message, including all the headers. ------\n");
-    # deliver.c:6425|          else fprintf(f,
-    # deliver.c:6426|"------ This is a copy of the message's headers. ------\n");
     'alias'   => qr/\A([ ]+an undisclosed address)\z/,
     'message' => qr{\A(?>
          This[ ]message[ ]was[ ]created[ ]automatically[ ]by[ ]mail[ ]delivery[ ]software[.]
@@ -42,11 +46,6 @@ my $MarkingsOf = {
         )
     }x,
     'frozen'  => qr/\AMessage .+ (?:has been frozen|was frozen on arrival)/,
-    'rfc822'  => qr{\A(?:
-         [-]+[ ]This[ ]is[ ]a[ ]copy[ ]of[ ](?:the|your)[ ]message.+headers[.][ ][-]+
-        |Content-Type:[ ]*message/rfc822
-        )\z
-    }x,
 };
 
 my $ReCommands = [
@@ -164,8 +163,7 @@ sub make {
     require Sisimai::RFC1894;
     my $fieldtable = Sisimai::RFC1894->FIELDTABLE;
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $localhost0 = '';    # (String) Local MTA
@@ -181,8 +179,9 @@ sub make {
         $boundary00 = Sisimai::MIME->boundary($mhead->{'content-type'});
     }
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         last if $e eq $StartingOf->{'endof'}->[0];
 
         unless( $readcursor ) {
@@ -192,140 +191,120 @@ sub make {
                 next unless $e =~ $MarkingsOf->{'frozen'};
             }
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( $e =~ $MarkingsOf->{'rfc822'} ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # This message was created automatically by mail delivery software.
+        #
+        # A message that you sent could not be delivered to one or more of its
+        # recipients. This is a permanent error. The following address(es) failed:
+        #
+        #  kijitora@example.jp
+        #    SMTP error from remote mail server after RCPT TO:<kijitora@example.jp>:
+        #    host neko.example.jp [192.0.2.222]: 550 5.1.1 <kijitora@example.jp>... User Unknown
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A[ \t]{2}([^ \t]+[@][^ \t]+[.]?[a-zA-Z]+)(:.+)?\z/ ||
+            $e =~ /\A[ \t]{2}[^ \t]+[@][^ \t]+[.][a-zA-Z]+[ ]<(.+?[@].+?)>:.+\z/ ||
+            $e =~ $MarkingsOf->{'alias'} ) {
+            #   kijitora@example.jp
+            #   sabineko@example.jp: forced freeze
+            #   mikeneko@example.jp <nekochan@example.org>: ...
+            #
+            # deliver.c:4549|  printed = US"an undisclosed address";
+            #   an undisclosed address
+            #     (generated from kijitora@example.jp)
+            my $r = $1;
+
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+
+            if( $e =~ /\A[ \t]+[^ \t]+[@][^ \t]+[.][a-zA-Z]+[ ]<(.+?[@].+?)>:.+\z/ ) {
+                # parser.c:743| while (bracket_count-- > 0) if (*s++ != '>')
+                # parser.c:744|   {
+                # parser.c:745|   *errorptr = s[-1] == 0
+                # parser.c:746|     ? US"'>' missing at end of address"
+                # parser.c:747|     : string_sprintf("malformed address: %.32s may not follow %.*s",
+                # parser.c:748|     s-1, (int)(s - US mailbox - 1), mailbox);
+                # parser.c:749|   goto PARSE_FAILED;
+                # parser.c:750|   }
+                $r = $1;
+                $v->{'diagnosis'} = $e;
+            }
+            $v->{'recipient'} = $r;
+            $recipients++;
+
+        } elsif( $e =~ /\A[ ]+[(]generated[ ]from[ ](.+)[)]\z/ ||
+                 $e =~ /\A[ ]+generated[ ]by[ ]([^ \t]+[@][^ \t]+)/ ) {
+            #     (generated from kijitora@example.jp)
+            #  pipe to |/bin/echo "Some pipe output"
+            #    generated by userx@myhost.test.ex
+            $v->{'alias'} = $1;
 
         } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
             next unless length $e;
 
-            # This message was created automatically by mail delivery software.
-            #
-            # A message that you sent could not be delivered to one or more of its
-            # recipients. This is a permanent error. The following address(es) failed:
-            #
-            #  kijitora@example.jp
-            #    SMTP error from remote mail server after RCPT TO:<kijitora@example.jp>:
-            #    host neko.example.jp [192.0.2.222]: 550 5.1.1 <kijitora@example.jp>... User Unknown
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A[ \t]{2}([^ \t]+[@][^ \t]+[.]?[a-zA-Z]+)(:.+)?\z/ ||
-                $e =~ /\A[ \t]{2}[^ \t]+[@][^ \t]+[.][a-zA-Z]+[ ]<(.+?[@].+?)>:.+\z/ ||
-                $e =~ $MarkingsOf->{'alias'} ) {
-                #   kijitora@example.jp
-                #   sabineko@example.jp: forced freeze
-                #   mikeneko@example.jp <nekochan@example.org>: ...
-                #
-                # deliver.c:4549|  printed = US"an undisclosed address";
-                #   an undisclosed address
-                #     (generated from kijitora@example.jp)
-                my $r = $1;
-
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-
-                if( $e =~ /\A[ \t]+[^ \t]+[@][^ \t]+[.][a-zA-Z]+[ ]<(.+?[@].+?)>:.+\z/ ) {
-                    # parser.c:743| while (bracket_count-- > 0) if (*s++ != '>')
-                    # parser.c:744|   {
-                    # parser.c:745|   *errorptr = s[-1] == 0
-                    # parser.c:746|     ? US"'>' missing at end of address"
-                    # parser.c:747|     : string_sprintf("malformed address: %.32s may not follow %.*s",
-                    # parser.c:748|     s-1, (int)(s - US mailbox - 1), mailbox);
-                    # parser.c:749|   goto PARSE_FAILED;
-                    # parser.c:750|   }
-                    $r = $1;
-                    $v->{'diagnosis'} = $e;
-                }
-                $v->{'recipient'} = $r;
-                $recipients++;
-
-            } elsif( $e =~ /\A[ ]+[(]generated[ ]from[ ](.+)[)]\z/ ||
-                     $e =~ /\A[ ]+generated[ ]by[ ]([^ \t]+[@][^ \t]+)/ ) {
-                #     (generated from kijitora@example.jp)
-                #  pipe to |/bin/echo "Some pipe output"
-                #    generated by userx@myhost.test.ex
-                $v->{'alias'} = $1;
+            if( $e =~ $MarkingsOf->{'frozen'} ) {
+                # Message *** has been frozen by the system filter.
+                # Message *** was frozen on arrival by ACL.
+                $v->{'alterrors'} .= $e.' ';
 
             } else {
-                next unless length $e;
+                if( $boundary00 ) {
+                    # --NNNNNNNNNN-eximdsn-MMMMMMMMMM
+                    # Content-type: message/delivery-status
+                    # ...
+                    if( Sisimai::RFC1894->match($e) ) {
+                        # $e matched with any field defined in RFC3464
+                        next unless my $o = Sisimai::RFC1894->field($e);
 
-                if( $e =~ $MarkingsOf->{'frozen'} ) {
-                    # Message *** has been frozen by the system filter.
-                    # Message *** was frozen on arrival by ACL.
-                    $v->{'alterrors'} .= $e.' ';
+                        if( $o->[-1] eq 'addr' ) {
+                            # Final-Recipient: rfc822;|/bin/echo "Some pipe output"
+                            next unless $o->[0] eq 'final-recipient';
+                            $v->{'spec'} ||= rindex($o->[2], '@') > -1 ? 'SMTP' : 'X-UNIX';
 
-                } else {
-                    if( $boundary00 ) {
-                        # --NNNNNNNNNN-eximdsn-MMMMMMMMMM
-                        # Content-type: message/delivery-status
-                        # ...
-                        if( Sisimai::RFC1894->match($e) ) {
-                            # $e matched with any field defined in RFC3464
-                            next unless my $o = Sisimai::RFC1894->field($e);
+                        } elsif( $o->[-1] eq 'code' ) {
+                            # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                            $v->{'spec'} = uc $o->[1];
+                            $v->{'diagnosis'} = $o->[2];
 
-                            if( $o->[-1] eq 'addr' ) {
-                                # Final-Recipient: rfc822;|/bin/echo "Some pipe output"
-                                next unless $o->[0] eq 'final-recipient';
-                                $v->{'spec'} ||= rindex($o->[2], '@') > -1 ? 'SMTP' : 'X-UNIX';
-
-                            } elsif( $o->[-1] eq 'code' ) {
-                                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                                $v->{'spec'} = uc $o->[1];
-                                $v->{'diagnosis'} = $o->[2];
-
-                            } else {
-                                # Other DSN fields defined in RFC3464
-                                next unless exists $fieldtable->{ $o->[0] };
-                                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-                            }
                         } else {
-                            # Error message ?
-                            next if $havepassed->{'deliverystatus'};
-                            # Content-type: message/delivery-status
-                            $havepassed->{'deliverystatus'} = 1 if index($e, $StartingOf->{'deliverystatus'}) == 0;
-                            $v->{'alterrors'} .= $e.' ' if index($e, ' ') == 0;
+                            # Other DSN fields defined in RFC3464
+                            next unless exists $fieldtable->{ $o->[0] };
+                            $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
                         }
                     } else {
-                        if( scalar @$dscontents == $recipients ) {
-                            # Error message
-                            next unless length $e;
-                            $v->{'diagnosis'} .= $e.' ';
+                        # Error message ?
+                        next if $havepassed->{'deliverystatus'};
+                        # Content-type: message/delivery-status
+                        $havepassed->{'deliverystatus'} = 1 if index($e, $StartingOf->{'deliverystatus'}) == 0;
+                        $v->{'alterrors'} .= $e.' ' if index($e, ' ') == 0;
+                    }
+                } else {
+                    if( scalar @$dscontents == $recipients ) {
+                        # Error message
+                        next unless length $e;
+                        $v->{'diagnosis'} .= $e.' ';
+
+                    } else {
+                        # Error message when email address above does not include '@'
+                        # and domain part.
+                        if( $e =~ m<\A[ ]+pipe[ ]to[ ][|]/.+> ) {
+                            # pipe to |/path/to/prog ...
+                            #   generated by kijitora@example.com
+                            $v->{'diagnosis'} = $e;
 
                         } else {
-                            # Error message when email address above does not include '@'
-                            # and domain part.
-                            if( $e =~ m<\A[ ]+pipe[ ]to[ ][|]/.+> ) {
-                                # pipe to |/path/to/prog ...
-                                #   generated by kijitora@example.com
-                                $v->{'diagnosis'} = $e;
-
-                            } else {
-                                next unless index($e, '    ') == 0;
-                                $v->{'alterrors'} .= $e.' ';
-                            }
+                            next unless index($e, '    ') == 0;
+                            $v->{'alterrors'} .= $e.' ';
                         }
                     }
                 }
             }
-        } # End of message/delivery-status
+        }
     }
 
     if( $recipients ) {
@@ -521,7 +500,7 @@ sub make {
         }
         $e->{'command'} ||= '';
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -567,7 +546,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Facebook.pm
+++ b/lib/Sisimai/Lhost/Facebook.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['This message was created automatically by Facebook.'],
-    'rfc822'  => ['Content-Disposition: inline'],
-};
+my $ReBackbone = qr|^Content-Disposition:[ ]inline|m;
+my $StartingOf = { 'message' => ['This message was created automatically by Facebook.'] };
 my $ErrorCodes = {
     # http://postmaster.facebook.com/response_codes
     # NOT TESTD EXCEPT RCP-P2
@@ -95,87 +93,65 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $fbresponse = '';    # (String) Response code from Facebook
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 or text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
             } else {
-                # Continued line of the value of Diagnostic-Code field
-                next unless index($p, 'Diagnostic-Code:') == 0;
-                next unless $e =~ /\A[ \t]+(.+)\z/;
-                $v->{'diagnosis'} .= ' '.$1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
-        } # End of message/delivery-status
+        } else {
+            # Continued line of the value of Diagnostic-Code field
+            next unless index($p, 'Diagnostic-Code:') == 0;
+            next unless $e =~ /\A[ \t]+(.+)\z/;
+            $v->{'diagnosis'} .= ' '.$1;
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -220,7 +196,7 @@ sub make {
         next unless $fbresponse =~ /\AINT-T\d+\z/;
         $e->{'reason'} = 'systemerror';
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -266,7 +242,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Facebook.pm
+++ b/lib/Sisimai/Lhost/Facebook.pm
@@ -165,10 +165,7 @@ sub make {
 
         if( $e->{'diagnosis'} =~ /\b([A-Z]{3})[-]([A-Z])(\d)\b/ ) {
             # Diagnostic-Code: smtp; 550 5.1.1 RCP-P2
-            my $lhs = $1;
-            my $rhs = $2;
-            my $num = $3;
-            $fbresponse = sprintf("%s-%s%d", $lhs, $rhs, $num);
+            $fbresponse = sprintf("%s-%s%d", $1, $2, $3);
         }
 
         SESSION: for my $r ( keys %$ErrorCodes ) {

--- a/lib/Sisimai/Lhost/Google.pm
+++ b/lib/Sisimai/Lhost/Google.pm
@@ -5,19 +5,12 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr/^[ ]*-----[ ](?:Original[ ]message|Message[ ]header[ ]follows)[ ]-----/m;
 my $StartingOf = {
     'message' => ['Delivery to the following recipient'],
     'error'   => ['The error that the other server returned was:'],
 };
-my $MarkingsOf = {
-    'start'   => qr/Technical details of (?:permanent|temporary) failure:/,
-    'rfc822'  => qr{\A(?:
-         -----[ ]Original[ ]message[ ]-----
-        |[ \t]*-----[ ]Message[ ]header[ ]follows[ ]-----
-        )\z
-    }x,
-};
-
+my $MarkingsOf = { 'start' => qr/Technical details of (?:permanent|temporary) failure:/ };
 my $MessagesOf = {
     'expired' => [
         'DNS Error: Could not contact DNS servers',
@@ -173,75 +166,55 @@ sub make {
     return undef unless index($mhead->{'subject'}, 'Delivery Status Notification') > -1;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $statecode0 = 0;     # (Integer) The value of (state *) in the error message
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) > -1;
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e =~ $MarkingsOf->{'rfc822'} ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # Technical details of permanent failure:=20
+        # Google tried to deliver your message, but it was rejected by the recipient =
+        # domain. We recommend contacting the other email provider for further inform=
+        # ation about the cause of this error. The error that the other server return=
+        # ed was: 554 554 5.7.0 Header error (state 18).
+        #
+        # -- OR --
+        #
+        # Technical details of permanent failure:=20
+        # Google tried to deliver your message, but it was rejected by the server for=
+        # the recipient domain example.jp by mx.example.jp. [192.0.2.49].
+        #
+        # The error that the other server returned was:
+        # 550 5.1.1 <userunknown@example.jp>... User Unknown
+        #
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A[ \t]+([^ ]+[@][^ ]+)\z/ ) {
+            # kijitora@example.jp: 550 5.2.2 <kijitora@example>... Mailbox Full
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+
+            my $r = Sisimai::Address->s3s4($1);
+            next unless Sisimai::RFC5322->is_emailaddress($r);
+            $v->{'recipient'} = $r;
+            $recipients++;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # Technical details of permanent failure:=20
-            # Google tried to deliver your message, but it was rejected by the recipient =
-            # domain. We recommend contacting the other email provider for further inform=
-            # ation about the cause of this error. The error that the other server return=
-            # ed was: 554 554 5.7.0 Header error (state 18).
-            #
-            # -- OR --
-            #
-            # Technical details of permanent failure:=20
-            # Google tried to deliver your message, but it was rejected by the server for=
-            # the recipient domain example.jp by mx.example.jp. [192.0.2.49].
-            #
-            # The error that the other server returned was:
-            # 550 5.1.1 <userunknown@example.jp>... User Unknown
-            #
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A[ \t]+([^ ]+[@][^ ]+)\z/ ) {
-                # kijitora@example.jp: 550 5.2.2 <kijitora@example>... Mailbox Full
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-
-                my $r = Sisimai::Address->s3s4($1);
-                next unless Sisimai::RFC5322->is_emailaddress($r);
-                $v->{'recipient'} = $r;
-                $recipients++;
-
-            } else {
-                $v->{'diagnosis'} .= $e.' ';
-            }
-        } # End of error message part
+            $v->{'diagnosis'} .= $e.' ';
+        }
     }
     return undef unless $recipients;
 
@@ -288,7 +261,7 @@ sub make {
         next unless $e->{'status'} =~ /\A[45][.][1-7][.][1-9]\z/;
         $e->{'reason'} = Sisimai::SMTP::Status->name($e->{'status'}) || '';
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -334,7 +307,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/InterScanMSS.pm
+++ b/lib/Sisimai/Lhost/InterScanMSS.pm
@@ -5,11 +5,6 @@ use strict;
 use warnings;
 
 my $ReBackbone = qr|^Content-type:[ ]message/rfc822|m;
-my $StartingOf = {
-    'message' => [''],
-    'rfc822'  => ['Content-type: message/rfc822'],
-};
-
 sub description { 'Trend Micro InterScan Messaging Security Suite' }
 sub make {
     # Detect an error from InterScanMSS

--- a/lib/Sisimai/Lhost/InterScanMSS.pm
+++ b/lib/Sisimai/Lhost/InterScanMSS.pm
@@ -4,7 +4,7 @@ use feature ':5.10';
 use strict;
 use warnings;
 
-my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr|^Content-type:[ ]message/rfc822|m;
 my $StartingOf = {
     'message' => [''],
     'rfc822'  => ['Content-type: message/rfc822'],
@@ -40,76 +40,47 @@ sub make {
     return undef unless $match;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
-    my $readcursor = 0;     # (Integer) Points the current cursor position
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
-        unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
-        }
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # Sent <<< RCPT TO:<kijitora@example.co.jp>
+        # Received >>> 550 5.1.1 <kijitora@example.co.jp>... user unknown
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
+        if( $e =~ /\A.+[<>]{3}[ \t]+.+[<]([^ ]+[@][^ ]+)[>]\z/ ||
+            $e =~ /\A.+[<>]{3}[ \t]+.+[<]([^ ]+[@][^ ]+)[>]/ ) {
             # Sent <<< RCPT TO:<kijitora@example.co.jp>
             # Received >>> 550 5.1.1 <kijitora@example.co.jp>... user unknown
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A.+[<>]{3}[ \t]+.+[<]([^ ]+[@][^ ]+)[>]\z/ ||
-                $e =~ /\A.+[<>]{3}[ \t]+.+[<]([^ ]+[@][^ ]+)[>]/ ) {
-                # Sent <<< RCPT TO:<kijitora@example.co.jp>
-                # Received >>> 550 5.1.1 <kijitora@example.co.jp>... user unknown
-                my $cr = $1;
-                if( $v->{'recipient'} && $cr ne $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $cr;
-                $recipients = scalar @$dscontents;
+            my $cr = $1;
+            if( $v->{'recipient'} && $cr ne $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
+            $v->{'recipient'} = $cr;
+            $recipients = scalar @$dscontents;
+        }
 
-            if( $e =~ /\ASent[ \t]+[<]{3}[ \t]+([A-Z]{4})[ \t]/ ) {
-                # Sent <<< RCPT TO:<kijitora@example.co.jp>
-                $v->{'command'} = $1
+        if( $e =~ /\ASent[ \t]+[<]{3}[ \t]+([A-Z]{4})[ \t]/ ) {
+            # Sent <<< RCPT TO:<kijitora@example.co.jp>
+            $v->{'command'} = $1
 
-            } elsif( $e =~ /\AReceived[ \t]+[>]{3}[ \t]+(\d{3}[ \t]+.+)\z/ ) {
-                # Received >>> 550 5.1.1 <kijitora@example.co.jp>... user unknown
-                $v->{'diagnosis'} = $1;
+        } elsif( $e =~ /\AReceived[ \t]+[>]{3}[ \t]+(\d{3}[ \t]+.+)\z/ ) {
+            # Received >>> 550 5.1.1 <kijitora@example.co.jp>... user unknown
+            $v->{'diagnosis'} = $1;
 
-            } else {
-                # Error message in non-English
-                next unless $e =~ /[ ][<>]{3}[ ]/;
-                $v->{'command'}   = $1 if $e =~ /[ ][>]{3}[ ]([A-Z]{4})/; # >>> RCPT TO ...
-                $v->{'diagnosis'} = $1 if $e =~ /[ ][<]{3}[ ](.+)/;       # <<< 550 5.1.1 User unknown
-            }
-        } # End of error message part
+        } else {
+            # Error message in non-English
+            next unless $e =~ /[ ][<>]{3}[ ]/;
+            $v->{'command'}   = $1 if $e =~ /[ ][>]{3}[ ]([A-Z]{4})/; # >>> RCPT TO ...
+            $v->{'diagnosis'} = $1 if $e =~ /[ ][<]{3}[ ](.+)/;       # <<< 550 5.1.1 User unknown
+        }
     }
     return undef unless $recipients;
 
@@ -118,7 +89,7 @@ sub make {
         $e->{'diagnosis'} = Sisimai::String->sweep($e->{'diagnosis'});
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -166,7 +137,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MXLogic.pm
+++ b/lib/Sisimai/Lhost/MXLogic.pm
@@ -6,11 +6,8 @@ use warnings;
 
 # Based on Sisimai::Lhost::Exim
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['This message was created automatically by mail delivery software.'],
-    'rfc822'  => ['Included is a copy of the message header:'],
-};
-
+my $ReBackbone = qr|^Included is a copy of the message header:|m;
+my $StartingOf = { 'message' => ['This message was created automatically by mail delivery software.'] };
 my $ReCommands = [
     qr/SMTP error from remote (?:mail server|mailer) after ([A-Za-z]{4})/,
     qr/SMTP error from remote (?:mail server|mailer) after end of ([A-Za-z]{4})/,
@@ -91,74 +88,52 @@ sub make {
     return undef unless $match;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $localhost0 = '';    # (String) Local MTA
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( $e eq $StartingOf->{'message'}->[0] ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e eq $StartingOf->{'rfc822'}->[0] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
+        # This message was created automatically by mail delivery software.
+        #
+        # A message that you sent could not be delivered to one or more of its
+        # recipients. This is a permanent error. The following address(es) failed:
+        #
+        #  kijitora@example.jp
+        #    SMTP error from remote mail server after RCPT TO:<kijitora@example.jp>:
+        #    host neko.example.jp [192.0.2.222]: 550 5.1.1 <kijitora@example.jp>... User Unknown
+        $v = $dscontents->[-1];
+
+        if( $e =~ /\A[ \t]*[<]([^ ]+[@][^ ]+)[>]:(.+)\z/ ) {
+            # A message that you have sent could not be delivered to one or more
+            # recipients.  This is a permanent error.  The following address failed:
+            #
+            #  <kijitora@example.co.jp>: 550 5.1.1 ...
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-        }
+            $v->{'recipient'} = $1;
+            $v->{'diagnosis'} = $2;
+            $recipients++;
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
+        } elsif( scalar @$dscontents == $recipients ) {
+            # Error message
             next unless length $e;
-
-            # This message was created automatically by mail delivery software.
-            #
-            # A message that you sent could not be delivered to one or more of its
-            # recipients. This is a permanent error. The following address(es) failed:
-            #
-            #  kijitora@example.jp
-            #    SMTP error from remote mail server after RCPT TO:<kijitora@example.jp>:
-            #    host neko.example.jp [192.0.2.222]: 550 5.1.1 <kijitora@example.jp>... User Unknown
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A[ \t]*[<]([^ ]+[@][^ ]+)[>]:(.+)\z/ ) {
-                # A message that you have sent could not be delivered to one or more
-                # recipients.  This is a permanent error.  The following address failed:
-                #
-                #  <kijitora@example.co.jp>: 550 5.1.1 ...
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $v->{'diagnosis'} = $2;
-                $recipients++;
-
-            } elsif( scalar @$dscontents == $recipients ) {
-                # Error message
-                next unless length $e;
-                $v->{'diagnosis'} .= $e.' ';
-            }
-        } # End of error message part
+            $v->{'diagnosis'} .= $e.' ';
+        }
     }
     return undef unless $recipients;
 
@@ -223,7 +198,7 @@ sub make {
         $e->{'command'} ||= '';
         $e->{'agent'}     = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -270,7 +245,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MailFoundry.pm
+++ b/lib/Sisimai/Lhost/MailFoundry.pm
@@ -5,9 +5,9 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
 my $StartingOf = {
     'message' => ['This is a MIME encoded message'],
-    'rfc822'  => ['Content-Type: message/rfc822'],
     'error'   => ['Delivery failed for the following reason:'],
 };
 
@@ -33,77 +33,55 @@ sub make {
     return undef unless grep { rindex($_, '(MAILFOUNDRY) id') > -1 } @{ $mhead->{'received'} };
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( $e eq $StartingOf->{'message'}->[0] ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e eq $StartingOf->{'rfc822'}->[0] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # Unable to deliver message to: <kijitora@example.org>
+        # Delivery failed for the following reason:
+        # Server mx22.example.org[192.0.2.222] failed with: 550 <kijitora@example.org> No such user here
+        #
+        # This has been a permanent failure.  No further delivery attempts will be made.
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\AUnable to deliver message to: [<]([^ ]+[@][^ ]+)[>]\z/ ) {
+            # Unable to deliver message to: <kijitora@example.org>
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+            $v->{'recipient'} = $1;
+            $recipients++;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # Unable to deliver message to: <kijitora@example.org>
-            # Delivery failed for the following reason:
-            # Server mx22.example.org[192.0.2.222] failed with: 550 <kijitora@example.org> No such user here
-            #
-            # This has been a permanent failure.  No further delivery attempts will be made.
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\AUnable to deliver message to: [<]([^ ]+[@][^ ]+)[>]\z/ ) {
-                # Unable to deliver message to: <kijitora@example.org>
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $recipients++;
+            # Error message
+            if( $e eq $StartingOf->{'error'}->[0] ) {
+                # Delivery failed for the following reason:
+                $v->{'diagnosis'} = $e;
 
             } else {
-                # Error message
-                if( $e eq $StartingOf->{'error'}->[0] ) {
-                    # Delivery failed for the following reason:
-                    $v->{'diagnosis'} = $e;
+                # Detect error message
+                next unless length $e;
+                next unless $v->{'diagnosis'};
+                next if index($e, '-') == 0;
 
-                } else {
-                    # Detect error message
-                    next unless length $e;
-                    next unless $v->{'diagnosis'};
-                    next if index($e, '-') == 0;
-
-                    # Server mx22.example.org[192.0.2.222] failed with: 550 <kijitora@example.org> No such user here
-                    $v->{'diagnosis'} .= ' '.$e;
-                }
+                # Server mx22.example.org[192.0.2.222] failed with: 550 <kijitora@example.org> No such user here
+                $v->{'diagnosis'} .= ' '.$e;
             }
-        } # End of error message part
+        }
     }
     return undef unless $recipients;
 
@@ -112,7 +90,7 @@ sub make {
         $e->{'diagnosis'} = Sisimai::String->sweep($e->{'diagnosis'});
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -158,7 +136,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MailMarshalSMTP.pm
+++ b/lib/Sisimai/Lhost/MailMarshalSMTP.pm
@@ -5,12 +5,12 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr/^[ \t]*[+]+[ \t]*/m;
 my $StartingOf = {
     'message'  => ['Your message:'],
     'error'    => ['Could not be delivered because of'],
     'rcpts'    => ['The following recipients were affected:'],
 };
-my $MarkingsOf = { 'rfc822' => undef };
 
 sub description { 'Trustwave Secure Email Gateway' }
 sub make {
@@ -32,8 +32,6 @@ sub make {
     return undef unless index($mhead->{'subject'}, 'Undeliverable Mail: "') == 0;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $endoferror = 0;     # (Integer) Flag for the end of error message
@@ -42,106 +40,87 @@ sub make {
     if( my $boundary00 = Sisimai::MIME->boundary($mhead->{'content-type'}) ) {
         # Convert to regular expression
         $boundary00 = '--'.$boundary00.'--';
-        $MarkingsOf->{'rfc822'} = qr/\A\Q$boundary00\E\z/;
-
-    } else {
-        $MarkingsOf->{'rfc822'} = qr/\A[ \t]*[+]+[ \t]*\z/;
+        $ReBackbone = qr/^\Q$boundary00\E/m;
     }
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            $readcursor |= $Indicators->{'deliverystatus'} if $e eq $StartingOf->{'message'}->[0];
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            $readcursor |= $Indicators->{'message-rfc822'} if $e =~ $MarkingsOf->{'rfc822'};
-        }
+        # Your message:
+        #    From:    originalsender@example.com
+        #    Subject: ...
+        #
+        # Could not be delivered because of
+        #
+        # 550 5.1.1 User unknown
+        #
+        # The following recipients were affected:
+        #    dummyuser@blabla.xxxxxxxxxxxx.com
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            last if $e =~ $MarkingsOf->{'rfc822'};
-
-            # Your message:
-            #    From:    originalsender@example.com
-            #    Subject: ...
-            #
-            # Could not be delivered because of
-            #
-            # 550 5.1.1 User unknown
-            #
+        if( $e =~ /\A[ \t]{4}([^ ]+[@][^ ]+)\z/ ) {
             # The following recipients were affected:
             #    dummyuser@blabla.xxxxxxxxxxxx.com
-            $v = $dscontents->[-1];
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
+            }
+            $v->{'recipient'} = $1;
+            $recipients++;
 
-            if( $e =~ /\A[ \t]{4}([^ ]+[@][^ ]+)\z/ ) {
-                # The following recipients were affected:
-                #    dummyuser@blabla.xxxxxxxxxxxx.com
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $recipients++;
+        } else {
+            # Get error message lines
+            if( $e eq $StartingOf->{'error'}->[0] ) {
+                # Could not be delivered because of
+                #
+                # 550 5.1.1 User unknown
+                $v->{'diagnosis'} = $e;
+
+            } elsif( $v->{'diagnosis'} && ! $endoferror ) {
+                # Append error messages
+                $endoferror = 1 if index($e, $StartingOf->{'rcpts'}->[0]) == 0;
+                next if $endoferror;
+
+                $v->{'diagnosis'} .= ' '.$e;
 
             } else {
-                # Get error message lines
-                if( $e eq $StartingOf->{'error'}->[0] ) {
-                    # Could not be delivered because of
-                    #
-                    # 550 5.1.1 User unknown
-                    $v->{'diagnosis'} = $e;
-
-                } elsif( $v->{'diagnosis'} && ! $endoferror ) {
-                    # Append error messages
-                    $endoferror = 1 if index($e, $StartingOf->{'rcpts'}->[0]) == 0;
-                    next if $endoferror;
-
-                    $v->{'diagnosis'} .= ' '.$e;
-
-                } else {
-                    # Additional Information
-                    # ======================
+                # Additional Information
+                # ======================
+                # Original Sender:    <originalsender@example.com>
+                # Sender-MTA:         <10.11.12.13>
+                # Remote-MTA:         <10.0.0.1>
+                # Reporting-MTA:      <relay.xxxxxxxxxxxx.com>
+                # MessageName:        <B549996730000.000000000001.0003.mml>
+                # Last-Attempt-Date:  <16:21:07 seg, 22 Dezembro 2014>
+                if( $e =~ /\AOriginal Sender:[ \t]+[<](.+)[>]\z/ ) {
                     # Original Sender:    <originalsender@example.com>
+                    # Use this line instead of "From" header of the original
+                    # message.
+                    $emailsteak->[1] .= sprintf("From: %s\n", $1);
+
+                } elsif( $e =~ /\ASender-MTA:[ \t]+[<](.+)[>]\z/ ) {
                     # Sender-MTA:         <10.11.12.13>
-                    # Remote-MTA:         <10.0.0.1>
+                    $v->{'lhost'} = $1;
+
+                } elsif( $e =~ /\AReporting-MTA:[ \t]+[<](.+)[>]\z/ ) {
                     # Reporting-MTA:      <relay.xxxxxxxxxxxx.com>
-                    # MessageName:        <B549996730000.000000000001.0003.mml>
-                    # Last-Attempt-Date:  <16:21:07 seg, 22 Dezembro 2014>
-                    if( $e =~ /\AOriginal Sender:[ \t]+[<](.+)[>]\z/ ) {
-                        # Original Sender:    <originalsender@example.com>
-                        # Use this line instead of "From" header of the original
-                        # message.
-                        push @$rfc822list, 'From: '.$1;
+                    $v->{'rhost'} = $1;
 
-                    } elsif( $e =~ /\ASender-MTA:[ \t]+[<](.+)[>]\z/ ) {
-                        # Sender-MTA:         <10.11.12.13>
-                        $v->{'lhost'} = $1;
-
-                    } elsif( $e =~ /\AReporting-MTA:[ \t]+[<](.+)[>]\z/ ) {
-                        # Reporting-MTA:      <relay.xxxxxxxxxxxx.com>
-                        $v->{'rhost'} = $1;
-
-                    } elsif( $e =~ /\A\s+(From|Subject):\s*(.+)\z/ ) {
-                        #    From:    originalsender@example.com
-                        #    Subject: ...
-                        push @$rfc822list, sprintf("%s: %s", $1, $2);
-                    }
+                } elsif( $e =~ /\A\s+(From|Subject):\s*(.+)\z/ ) {
+                    #    From:    originalsender@example.com
+                    #    Subject: ...
+                    $emailsteak->[1] .= sprintf("%s: %s\n", $1, $2);
                 }
             }
-        } # End of error message part
+        }
     }
     return undef unless $recipients;
 
@@ -149,7 +128,7 @@ sub make {
         $e->{'diagnosis'} = Sisimai::String->sweep($e->{'diagnosis'});
         $e->{'agent'}     = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -197,7 +176,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MessageLabs.pm
+++ b/lib/Sisimai/Lhost/MessageLabs.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['Content-Type: message/delivery-status'],
-    'rfc822'  => ['Content-Type: text/rfc822-headers'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]text/rfc822-headers|m;
+my $StartingOf = { 'message' => ['Content-Type: message/delivery-status'] };
 my $ReFailures = {
     'userunknown'   => qr/(?:542 .+ Rejected|No such user)/,
     'securityerror' => qr/Please turn on SMTP Authentication in your mail client/,
@@ -47,85 +45,63 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( $e eq $StartingOf->{'rfc822'}->[0] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
             } else {
-                # Continued line of the value of Diagnostic-Code field
-                next unless index($p, 'Diagnostic-Code:') == 0;
-                next unless $e =~ /\A[ \t]+(.+)\z/;
-                $v->{'diagnosis'} .= ' '.$1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
+        } else {
+            # Continued line of the value of Diagnostic-Code field
+            next unless index($p, 'Diagnostic-Code:') == 0;
+            next unless $e =~ /\A[ \t]+(.+)\z/;
+            $v->{'diagnosis'} .= ' '.$1;
         } # End of message/delivery-status
     } continue {
         # Save the current line for the next loop
@@ -147,7 +123,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -194,7 +170,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MessagingServer.pm
+++ b/lib/Sisimai/Lhost/MessagingServer.pm
@@ -5,8 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr<\A(?:Content-type:[ \t]*message/rfc822|Return-path:[ \t]*)>m;
 my $StartingOf = { 'message' => ['This report relates to a message you sent with the following header fields:'] };
-my $MarkingsOf = { 'rfc822'  => qr!\A(?:Content-type:[ \t]*message/rfc822|Return-path:[ \t]*)! };
 my $MessagesOf = { 'hostunknown' => ['Illegal host/domain name found'] };
 
 sub description { 'Oracle Communications Messaging Server' }
@@ -34,131 +34,109 @@ sub make {
     return undef unless $match;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e =~ $MarkingsOf->{'rfc822'} ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # --Boundary_(ID_0000000000000000000000)
+        # Content-type: text/plain; charset=us-ascii
+        # Content-language: en-US
+        #
+        # This report relates to a message you sent with the following header fields:
+        #
+        #   Message-id: <CD8C6134-C312-41D5-B083-366F7FA1D752@me.example.com>
+        #   Date: Fri, 21 Nov 2014 23:34:45 +0900
+        #   From: Shironeko <shironeko@me.example.com>
+        #   To: kijitora@example.jp
+        #   Subject: Nyaaaaaaaaaaaaaaaaaaaaaan
+        #
+        # Your message cannot be delivered to the following recipients:
+        #
+        #   Recipient address: kijitora@example.jp
+        #   Reason: Remote SMTP server has rejected address
+        #   Diagnostic code: smtp;550 5.1.1 <kijitora@example.jp>... User Unknown
+        #   Remote system: dns;mx.example.jp (TCP|17.111.174.67|47323|192.0.2.225|25) (6jo.example.jp ESMTP SENDMAIL-VM)
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A[ \t]+Recipient address:[ \t]*([^ ]+[@][^ ]+)\z/ ) {
+            #   Recipient address: kijitora@example.jp
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+            $v->{'recipient'} = Sisimai::Address->s3s4($1);
+            $recipients++;
+
+        } elsif( $e =~ /\A[ \t]+Original address:[ \t]*([^ ]+[@][^ ]+)\z/ ) {
+            #   Original address: kijitora@example.jp
+            $v->{'recipient'} = Sisimai::Address->s3s4($1);
+
+        } elsif( $e =~ /\A[ \t]+Date:[ \t]*(.+)\z/ ) {
+            #   Date: Fri, 21 Nov 2014 23:34:45 +0900
+            $v->{'date'} = $1;
+
+        } elsif( $e =~ /\A[ \t]+Reason:[ \t]*(.+)\z/ ) {
+            #   Reason: Remote SMTP server has rejected address
+            $v->{'diagnosis'} = $1;
+
+        } elsif( $e =~ /\A[ \t]+Diagnostic code:[ \t]*([^ ]+);(.+)\z/ ) {
+            #   Diagnostic code: smtp;550 5.1.1 <kijitora@example.jp>... User Unknown
+            $v->{'spec'} = uc $1;
+            $v->{'diagnosis'} = $2;
+
+        } elsif( $e =~ /\A[ \t]+Remote system:[ \t]*dns;([^ ]+)[ \t]*([^ ]+)[ \t]*.+\z/ ) {
+            #   Remote system: dns;mx.example.jp (TCP|17.111.174.67|47323|192.0.2.225|25)
+            #     (6jo.example.jp ESMTP SENDMAIL-VM)
+            my $remotehost = $1; # remote host
+            my $sessionlog = $2; # smtp session
+            $v->{'rhost'} = $remotehost;
+
+            # The value does not include ".", use IP address instead.
+            # (TCP|17.111.174.67|47323|192.0.2.225|25)
+            next unless $sessionlog =~ /\A[(]TCP|(.+)|\d+|(.+)|\d+[)]/;
+            $v->{'lhost'} = $1;
+            $v->{'rhost'} = $2 unless $remotehost =~ /[^.]+[.][^.]+/;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # --Boundary_(ID_0000000000000000000000)
-            # Content-type: text/plain; charset=us-ascii
-            # Content-language: en-US
+            # Original-envelope-id: 0NFC009FLKOUVMA0@mr21p30im-asmtp004.me.com
+            # Reporting-MTA: dns;mr21p30im-asmtp004.me.com (tcp-daemon)
+            # Arrival-date: Thu, 29 Apr 2014 23:34:45 +0000 (GMT)
             #
-            # This report relates to a message you sent with the following header fields:
+            # Original-recipient: rfc822;kijitora@example.jp
+            # Final-recipient: rfc822;kijitora@example.jp
+            # Action: failed
+            # Status: 5.1.1 (Remote SMTP server has rejected address)
+            # Remote-MTA: dns;mx.example.jp (TCP|17.111.174.67|47323|192.0.2.225|25)
+            #  (6jo.example.jp ESMTP SENDMAIL-VM)
+            # Diagnostic-code: smtp;550 5.1.1 <kijitora@example.jp>... User Unknown
             #
-            #   Message-id: <CD8C6134-C312-41D5-B083-366F7FA1D752@me.example.com>
-            #   Date: Fri, 21 Nov 2014 23:34:45 +0900
-            #   From: Shironeko <shironeko@me.example.com>
-            #   To: kijitora@example.jp
-            #   Subject: Nyaaaaaaaaaaaaaaaaaaaaaan
-            #
-            # Your message cannot be delivered to the following recipients:
-            #
-            #   Recipient address: kijitora@example.jp
-            #   Reason: Remote SMTP server has rejected address
-            #   Diagnostic code: smtp;550 5.1.1 <kijitora@example.jp>... User Unknown
-            #   Remote system: dns;mx.example.jp (TCP|17.111.174.67|47323|192.0.2.225|25) (6jo.example.jp ESMTP SENDMAIL-VM)
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A[ \t]+Recipient address:[ \t]*([^ ]+[@][^ ]+)\z/ ) {
-                #   Recipient address: kijitora@example.jp
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = Sisimai::Address->s3s4($1);
-                $recipients++;
-
-            } elsif( $e =~ /\A[ \t]+Original address:[ \t]*([^ ]+[@][^ ]+)\z/ ) {
-                #   Original address: kijitora@example.jp
-                $v->{'recipient'} = Sisimai::Address->s3s4($1);
-
-            } elsif( $e =~ /\A[ \t]+Date:[ \t]*(.+)\z/ ) {
-                #   Date: Fri, 21 Nov 2014 23:34:45 +0900
-                $v->{'date'} = $1;
-
-            } elsif( $e =~ /\A[ \t]+Reason:[ \t]*(.+)\z/ ) {
-                #   Reason: Remote SMTP server has rejected address
-                $v->{'diagnosis'} = $1;
-
-            } elsif( $e =~ /\A[ \t]+Diagnostic code:[ \t]*([^ ]+);(.+)\z/ ) {
-                #   Diagnostic code: smtp;550 5.1.1 <kijitora@example.jp>... User Unknown
-                $v->{'spec'} = uc $1;
-                $v->{'diagnosis'} = $2;
-
-            } elsif( $e =~ /\A[ \t]+Remote system:[ \t]*dns;([^ ]+)[ \t]*([^ ]+)[ \t]*.+\z/ ) {
-                #   Remote system: dns;mx.example.jp (TCP|17.111.174.67|47323|192.0.2.225|25)
-                #     (6jo.example.jp ESMTP SENDMAIL-VM)
-                my $remotehost = $1; # remote host
-                my $sessionlog = $2; # smtp session
-                $v->{'rhost'} = $remotehost;
-
-                # The value does not include ".", use IP address instead.
-                # (TCP|17.111.174.67|47323|192.0.2.225|25)
-                next unless $sessionlog =~ /\A[(]TCP|(.+)|\d+|(.+)|\d+[)]/;
-                $v->{'lhost'} = $1;
-                $v->{'rhost'} = $2 unless $remotehost =~ /[^.]+[.][^.]+/;
-
-            } else {
-                # Original-envelope-id: 0NFC009FLKOUVMA0@mr21p30im-asmtp004.me.com
-                # Reporting-MTA: dns;mr21p30im-asmtp004.me.com (tcp-daemon)
-                # Arrival-date: Thu, 29 Apr 2014 23:34:45 +0000 (GMT)
-                #
-                # Original-recipient: rfc822;kijitora@example.jp
-                # Final-recipient: rfc822;kijitora@example.jp
-                # Action: failed
+            if( $e =~ /\AStatus:[ \t]*(\d[.]\d[.]\d)[ \t]*[(](.+)[)]\z/ ) {
                 # Status: 5.1.1 (Remote SMTP server has rejected address)
-                # Remote-MTA: dns;mx.example.jp (TCP|17.111.174.67|47323|192.0.2.225|25)
-                #  (6jo.example.jp ESMTP SENDMAIL-VM)
-                # Diagnostic-code: smtp;550 5.1.1 <kijitora@example.jp>... User Unknown
-                #
-                if( $e =~ /\AStatus:[ \t]*(\d[.]\d[.]\d)[ \t]*[(](.+)[)]\z/ ) {
-                    # Status: 5.1.1 (Remote SMTP server has rejected address)
-                    $v->{'status'} = $1;
-                    $v->{'diagnosis'} ||= $2;
+                $v->{'status'} = $1;
+                $v->{'diagnosis'} ||= $2;
 
-                } elsif( $e =~ /\AArrival-Date:[ ]*(.+)\z/ ) {
-                    # Arrival-date: Thu, 29 Apr 2014 23:34:45 +0000 (GMT)
-                    $v->{'date'} ||= $1;
+            } elsif( $e =~ /\AArrival-Date:[ ]*(.+)\z/ ) {
+                # Arrival-date: Thu, 29 Apr 2014 23:34:45 +0000 (GMT)
+                $v->{'date'} ||= $1;
 
-                } elsif( $e =~ /\AReporting-MTA:[ ]*(?:DNS|dns);[ ]*(.+)\z/ ) {
-                    # Reporting-MTA: dns;mr21p30im-asmtp004.me.com (tcp-daemon)
-                    my $localhost = $1;
-                    $v->{'lhost'} ||= $localhost;
-                    $v->{'lhost'}   = $localhost unless $v->{'lhost'} =~ /[^.]+[.][^ ]+/;
-                }
+            } elsif( $e =~ /\AReporting-MTA:[ ]*(?:DNS|dns);[ ]*(.+)\z/ ) {
+                # Reporting-MTA: dns;mr21p30im-asmtp004.me.com (tcp-daemon)
+                my $localhost = $1;
+                $v->{'lhost'} ||= $localhost;
+                $v->{'lhost'}   = $localhost unless $v->{'lhost'} =~ /[^.]+[.][^ ]+/;
             }
         } # End of error message part
     }
@@ -175,7 +153,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -223,7 +201,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MessagingServer.pm
+++ b/lib/Sisimai/Lhost/MessagingServer.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $ReBackbone = qr<\A(?:Content-type:[ \t]*message/rfc822|Return-path:[ \t]*)>m;
+my $ReBackbone = qr<^(?:Content-type:[ \t]*message/rfc822|Return-path:[ \t]*)>m;
 my $StartingOf = { 'message' => ['This report relates to a message you sent with the following header fields:'] };
 my $MessagesOf = { 'hostunknown' => ['Illegal host/domain name found'] };
 

--- a/lib/Sisimai/Lhost/Notes.pm
+++ b/lib/Sisimai/Lhost/Notes.pm
@@ -56,6 +56,7 @@ sub make {
             next;
         }
         next unless $readcursor & $Indicators->{'deliverystatus'};
+
         # ------- Failure Reasons  --------
         #
         # User not listed in public Name & Address Book

--- a/lib/Sisimai/Lhost/Outlook.pm
+++ b/lib/Sisimai/Lhost/Outlook.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['This is an automatically generated Delivery Status Notification'],
-    'rfc822'  => ['Content-Type: message/rfc822'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
+my $StartingOf = { 'message' => ['This is an automatically generated Delivery Status Notification'] };
 my $MessagesOf = {
     'hostunknown' => ['The mail could not be delivered to the recipient because the domain is not reachable'],
     'userunknown' => ['Requested action not taken: mailbox unavailable'],
@@ -48,86 +46,64 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( $e eq $StartingOf->{'rfc822'}->[0] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
             } else {
-                # Continued line of the value of Diagnostic-Code field
-                next unless index($p, 'Diagnostic-Code:') == 0;
-                next unless $e =~ /\A[ \t]+(.+)\z/;
-                $v->{'diagnosis'} .= ' '.$1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
-        } # End of message/delivery-status
+        } else {
+            # Continued line of the value of Diagnostic-Code field
+            next unless index($p, 'Diagnostic-Code:') == 0;
+            next unless $e =~ /\A[ \t]+(.+)\z/;
+            $v->{'diagnosis'} .= ' '.$1;
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -161,7 +137,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -207,7 +183,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/ReceivingSES.pm
+++ b/lib/Sisimai/Lhost/ReceivingSES.pm
@@ -6,10 +6,8 @@ use warnings;
 
 # https://aws.amazon.com/ses/
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['This message could not be delivered.'],
-    'rfc822'  => ['content-type: text/rfc822-headers'],
-};
+my $ReBackbone = qr|^content-type:[ ]text/rfc822-headers|m;
+my $StartingOf = { 'message' => ['This message could not be delivered.'] };
 my $MessagesOf = {
     # The followings are error messages in Rule sets/*/Actions/Template
     'filtered'     => ['Mailbox does not exist'],
@@ -48,86 +46,64 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( $e eq $StartingOf->{'message'}->[0] ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( $e eq $StartingOf->{'rfc822'}->[0] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
             } else {
-                # Continued line of the value of Diagnostic-Code field
-                next unless index($p, 'Diagnostic-Code:') == 0;
-                next unless $e =~ /\A[ \t]+(.+)\z/;
-                $v->{'diagnosis'} .= ' '.$1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
-        } # End of message/delivery-status
+        } else {
+            # Continued line of the value of Diagnostic-Code field
+            next unless index($p, 'Diagnostic-Code:') == 0;
+            next unless $e =~ /\A[ \t]+(.+)\z/;
+            $v->{'diagnosis'} .= ' '.$1;
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -158,7 +134,7 @@ sub make {
         $e->{'reason'} ||= Sisimai::SMTP::Status->name($e->{'status'}) || '';
         $e->{'agent'}    = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -204,7 +180,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/SendGrid.pm
+++ b/lib/Sisimai/Lhost/SendGrid.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['This is an automatically generated message from SendGrid.'],
-    'rfc822'  => ['Content-Type: message/rfc822'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
+my $StartingOf = { 'message' => ['This is an automatically generated message from SendGrid.'] };
 
 # Return-Path: <apps@sendgrid.net>
 # X-Mailer: MIME-tools 5.502 (Entity 5.502)
@@ -41,126 +39,104 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( $e eq $StartingOf->{'message'}->[0] ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
+
+            unless( $o ) {
+                # Fallback code for empty value or invalid formatted value
+                # - Status: (empty)
+                # - Diagnostic-Code: 550 5.1.1 ... (No "diagnostic-type" sub field)
+                $v->{'diagnosis'} = $1 if $e =~ /\ADiagnostic-Code:[ ]*(.+)/;
                 next;
             }
-        }
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                unless( $o ) {
-                    # Fallback code for empty value or invalid formatted value
-                    # - Status: (empty)
-                    # - Diagnostic-Code: 550 5.1.1 ... (No "diagnostic-type" sub field)
-                    $v->{'diagnosis'} = $1 if $e =~ /\ADiagnostic-Code:[ ]*(.+)/;
-                    next;
-                }
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
-                } elsif( $o->[-1] eq 'date' ) {
-                    # Arrival-Date: 2012-12-31 23-59-59
-                    next unless $e =~ /\AArrival-Date: (\d{4})[-](\d{2})[-](\d{2}) (\d{2})[-](\d{2})[-](\d{2})\z/;
-                    $o->[1] .= 'Thu, '.$3.' ';
-                    $o->[1] .= Sisimai::DateTime->monthname(0)->[int($2) - 1];
-                    $o->[1] .= ' '.$1.' '.join(':', $4, $5, $6);
-                    $o->[1] .= ' '.Sisimai::DateTime->abbr2tz('CDT');
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
+            } elsif( $o->[-1] eq 'date' ) {
+                # Arrival-Date: 2012-12-31 23-59-59
+                next unless $e =~ /\AArrival-Date: (\d{4})[-](\d{2})[-](\d{2}) (\d{2})[-](\d{2})[-](\d{2})\z/;
+                $o->[1] .= 'Thu, '.$3.' ';
+                $o->[1] .= Sisimai::DateTime->monthname(0)->[int($2) - 1];
+                $o->[1] .= ' '.$1.' '.join(':', $4, $5, $6);
+                $o->[1] .= ' '.Sisimai::DateTime->abbr2tz('CDT');
             } else {
-                # This is an automatically generated message from SendGrid.
-                #
-                # I'm sorry to have to tell you that your message was not able to be
-                # delivered to one of its intended recipients.
-                #
-                # If you require assistance with this, please contact SendGrid support.
-                #
-                # shironekochan:000000:<kijitora@example.jp> : 192.0.2.250 : mx.example.jp:[192.0.2.153] :
-                #   550 5.1.1 <userunknown@cubicroot.jp>... User Unknown  in RCPT TO
-                #
-                # ------------=_1351676802-30315-116783
-                # Content-Type: message/delivery-status
-                # Content-Disposition: inline
-                # Content-Transfer-Encoding: 7bit
-                # Content-Description: Delivery Report
-                #
-                # X-SendGrid-QueueID: 959479146
-                # X-SendGrid-Sender: <bounces+61689-10be-kijitora=example.jp@sendgrid.info>
-                if( $e =~ /.+ in (?:End of )?([A-Z]{4}).*\z/ ) {
-                    # in RCPT TO, in MAIL FROM, end of DATA
-                    $commandtxt = $1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
 
-                } else {
-                    # Continued line of the value of Diagnostic-Code field
-                    next unless index($p, 'Diagnostic-Code:') == 0;
-                    next unless $e =~ /\A[ \t]+(.+)\z/;
-                    $v->{'diagnosis'} .= ' '.$1;
-                }
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
-        } # End of message/delivery-status
+        } else {
+            # This is an automatically generated message from SendGrid.
+            #
+            # I'm sorry to have to tell you that your message was not able to be
+            # delivered to one of its intended recipients.
+            #
+            # If you require assistance with this, please contact SendGrid support.
+            #
+            # shironekochan:000000:<kijitora@example.jp> : 192.0.2.250 : mx.example.jp:[192.0.2.153] :
+            #   550 5.1.1 <userunknown@cubicroot.jp>... User Unknown  in RCPT TO
+            #
+            # ------------=_1351676802-30315-116783
+            # Content-Type: message/delivery-status
+            # Content-Disposition: inline
+            # Content-Transfer-Encoding: 7bit
+            # Content-Description: Delivery Report
+            #
+            # X-SendGrid-QueueID: 959479146
+            # X-SendGrid-Sender: <bounces+61689-10be-kijitora=example.jp@sendgrid.info>
+            if( $e =~ /.+ in (?:End of )?([A-Z]{4}).*\z/ ) {
+                # in RCPT TO, in MAIL FROM, end of DATA
+                $commandtxt = $1;
+
+            } else {
+                # Continued line of the value of Diagnostic-Code field
+                next unless index($p, 'Diagnostic-Code:') == 0;
+                next unless $e =~ /\A[ \t]+(.+)\z/;
+                $v->{'diagnosis'} .= ' '.$1;
+            }
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -191,7 +167,7 @@ sub make {
         $e->{'lhost'}   ||= $permessage->{'rhost'};
         $e->{'command'} ||= $commandtxt;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -237,7 +213,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Sendmail.pm
+++ b/lib/Sisimai/Lhost/Sendmail.pm
@@ -5,8 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr<^Content-Type:[ ](?:message/rfc822|text/rfc822-headers)>m;
 my $StartingOf = {
-    # Error text regular expressions which defined in sendmail/savemail.c
     #   savemail.c:1040|if (printheader && !putline("   ----- Transcript of session follows -----\n",
     #   savemail.c:1041|          mci))
     #   savemail.c:1042|  goto writeerr;
@@ -14,7 +14,6 @@ my $StartingOf = {
     #   savemail.c:1361|    sendbody
     #   savemail.c:1362|    ? "   ----- Original message follows -----\n"
     #   savemail.c:1363|    : "   ----- Message header follows -----\n",
-    'rfc822'  => ['Content-Type: message/rfc822', 'Content-Type: text/rfc822-headers'],
     'message' => ['   ----- Transcript of session follows -----'],
     'error'   => ['... while talking to '],
 };
@@ -49,10 +48,8 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
-
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $commandtxt = '';    # (String) SMTP Command name begin with the string '>>>'
     my $esmtpreply = [];    # (Array) Reply from remote server on SMTP session
@@ -61,133 +58,111 @@ sub make {
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ||
-                index($e, $StartingOf->{'rfc822'}->[1]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
+                }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
 
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            } else {
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
+
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+            }
+        } else {
+            # The line does not begin with a DSN field defined in RFC3464
+            #
+            # ----- Transcript of session follows -----
+            # ... while talking to mta.example.org.:
+            # >>> DATA
+            # <<< 550 Unknown user recipient@example.jp
+            # 554 5.0.0 Service unavailable
+            if( substr($e, 0, 1) ne ' ') {
+                # Other error messages
+                if( $e =~ /\A[>]{3}[ ]+([A-Z]{4})[ ]?/ ) {
+                    # >>> DATA
+                    $commandtxt = $1;
+
+                } elsif( $e =~ /\A[<]{3}[ ]+(.+)\z/ ) {
+                    # <<< Response
+                    push @$esmtpreply, $1 unless grep { $1 eq $_ } @$esmtpreply;
+
+                } else {
+                    # Detect SMTP session error or connection error
+                    next if $sessionerr;
+                    if( index($e, $StartingOf->{'error'}->[0]) == 0 ) {
+                        # ----- Transcript of session follows -----
+                        # ... while talking to mta.example.org.:
+                        $sessionerr = 1;
+                        next;
+                    }
+
+                    if( $e =~ /\A[<](.+)[>][.]+ (.+)\z/ ) {
+                        # <kijitora@example.co.jp>... Deferred: Name server: example.co.jp.: host name lookup failure
+                        $anotherset->{'recipient'} = $1;
+                        $anotherset->{'diagnosis'} = $2;
+
+                    } else {
+                        # ----- Transcript of session follows -----
+                        # Message could not be delivered for too long
+                        # Message will be deleted from queue
+                        if( $e =~ /\A[45]\d\d[ \t]([45][.]\d[.]\d)[ \t].+/ ) {
+                            # 550 5.1.2 <kijitora@example.org>... Message
+                            #
+                            # DBI connect('dbname=...')
+                            # 554 5.3.0 unknown mailer error 255
+                            $anotherset->{'status'} = $1;
+                            $anotherset->{'diagnosis'} .= ' '.$e;
+
+                        } elsif( index($e, 'Message: ') == 0 || index($e, 'Warning: ') == 0 ) {
+                            # Message could not be delivered for too long
+                            # Warning: message still undelivered after 4 hours
+                            $anotherset->{'diagnosis'} .= ' '.$e;
+                        }
+                    }
                 }
             } else {
-                # The line does not begin with a DSN field defined in RFC3464
-                #
-                # ----- Transcript of session follows -----
-                # ... while talking to mta.example.org.:
-                # >>> DATA
-                # <<< 550 Unknown user recipient@example.jp
-                # 554 5.0.0 Service unavailable
-                if( substr($e, 0, 1) ne ' ') {
-                    # Other error messages
-                    if( $e =~ /\A[>]{3}[ ]+([A-Z]{4})[ ]?/ ) {
-                        # >>> DATA
-                        $commandtxt = $1;
-
-                    } elsif( $e =~ /\A[<]{3}[ ]+(.+)\z/ ) {
-                        # <<< Response
-                        push @$esmtpreply, $1 unless grep { $1 eq $_ } @$esmtpreply;
-
-                    } else {
-                        # Detect SMTP session error or connection error
-                        next if $sessionerr;
-                        if( index($e, $StartingOf->{'error'}->[0]) == 0 ) {
-                            # ----- Transcript of session follows -----
-                            # ... while talking to mta.example.org.:
-                            $sessionerr = 1;
-                            next;
-                        }
-
-                        if( $e =~ /\A[<](.+)[>][.]+ (.+)\z/ ) {
-                            # <kijitora@example.co.jp>... Deferred: Name server: example.co.jp.: host name lookup failure
-                            $anotherset->{'recipient'} = $1;
-                            $anotherset->{'diagnosis'} = $2;
-
-                        } else {
-                            # ----- Transcript of session follows -----
-                            # Message could not be delivered for too long
-                            # Message will be deleted from queue
-                            if( $e =~ /\A[45]\d\d[ \t]([45][.]\d[.]\d)[ \t].+/ ) {
-                                # 550 5.1.2 <kijitora@example.org>... Message
-                                #
-                                # DBI connect('dbname=...')
-                                # 554 5.3.0 unknown mailer error 255
-                                $anotherset->{'status'} = $1;
-                                $anotherset->{'diagnosis'} .= ' '.$e;
-
-                            } elsif( index($e, 'Message: ') == 0 || index($e, 'Warning: ') == 0 ) {
-                                # Message could not be delivered for too long
-                                # Warning: message still undelivered after 4 hours
-                                $anotherset->{'diagnosis'} .= ' '.$e;
-                            }
-                        }
-                    }
-                } else {
-                    # Continued line of the value of Diagnostic-Code field
-                    next unless index($p, 'Diagnostic-Code:') == 0;
-                    next unless $e =~ /\A[ \t]+(.+)\z/;
-                    $v->{'diagnosis'} .= ' '.$1;
-                }
+                # Continued line of the value of Diagnostic-Code field
+                next unless index($p, 'Diagnostic-Code:') == 0;
+                next unless $e =~ /\A[ \t]+(.+)\z/;
+                $v->{'diagnosis'} .= ' '.$1;
             }
-        } # End of message/delivery-status
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -228,7 +203,7 @@ sub make {
         next if $e->{'recipient'} =~ /\A[^ ]+[@][^ ]+\z/;
         $e->{'recipient'} = $1 if $e->{'diagnosis'} =~ /[<]([^ ]+[@][^ ]+)[>]/;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -274,7 +249,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/UserDefined.pm
+++ b/lib/Sisimai/Lhost/UserDefined.pm
@@ -55,7 +55,7 @@ sub make {
     #
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
     my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
-    my @hasdivided = split("\n", $emailsteak->[0]);
+    my @bodyslices = split("\n", $emailsteak->[0]);
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
 
     # The following code is dummy to be passed "make test".

--- a/lib/Sisimai/Lhost/V5sendmail.pm
+++ b/lib/Sisimai/Lhost/V5sendmail.pm
@@ -120,13 +120,10 @@ sub make {
         }
     }
 
-    unless( $recipients ) {
-        # Get the recipient address from the original message
-        if( $emailsteak->[1] =~ /^To:[ ]*(.+)/m ) {
-            # The value of To: header in the original message
-            $dscontents->[0]->{'recipient'} = Sisimai::Address->s3s4($1);
-            $recipients = 1;
-        }
+    if( $recipients == 0 && $emailsteak->[1] =~ /^To:[ ]*(.+)/m ) {
+        # Get the recipient address from "To:" header at the original message
+        $dscontents->[0]->{'recipient'} = Sisimai::Address->s3s4($1);
+        $recipients = 1;
     }
     return undef unless $recipients;
 

--- a/lib/Sisimai/Lhost/V5sendmail.pm
+++ b/lib/Sisimai/Lhost/V5sendmail.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr/^[ ]+-----[ ](?:Unsent[ ]message[ ]follows|No[ ]message[ ]was[ ]collected)[ ]-----/m;
 my $StartingOf = { 'message' => ['----- Transcript of session follows -----'] };
 my $MarkingsOf = {
     # Error text regular expressions which defined in src/savemail.c
@@ -23,12 +24,7 @@ my $MarkingsOf = {
     #   savemail.c:497|   while (fgets(buf, sizeof buf, xfile) != NULL)
     #   savemail.c:498|       putline(buf, fp, m);
     #   savemail.c:499|   (void) fclose(xfile);
-    'error'   => qr/\A[.]+ while talking to .+[:]\z/,
-    'rfc822'  => qr{\A[ \t]+-----[ \t](?:
-         Unsent[ ]message[ ]follows
-        |No[ ]message[ ]was[ ]collected
-        )[ \t]-----
-    }x,
+    'error' => qr/\A[.]+ while talking to .+[:]\z/,
 };
 
 sub description { 'Sendmail version 5' }
@@ -52,9 +48,10 @@ sub make {
     # 'from'    => qr/\AMail Delivery Subsystem/,
     return undef unless $mhead->{'subject'} =~ /\AReturned mail: [A-Z]/;
 
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
+    return undef unless length $emailsteak->[1];
+
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $anotherset = {};    # (Ref->Hash) Another error information
@@ -63,96 +60,72 @@ sub make {
     my $errorindex = -1;
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( rindex($e, $StartingOf->{'message'}->[0]) > -1 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) > -1;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e =~ $MarkingsOf->{'rfc822'} ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        #    ----- Transcript of session follows -----
+        # While talking to smtp.example.com:
+        # >>> RCPT To:<kijitora@example.org>
+        # <<< 550 <kijitora@example.org>, User Unknown
+        # 550 <kijitora@example.org>... User unknown
+        # 421 example.org (smtp)... Deferred: Connection timed out during user open with example.org
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
+        if( $e =~ /\A\d{3}[ \t]+[<]([^ ]+[@][^ ]+)[>][.]{3}[ \t]*(.+)\z/ ) {
+            # 550 <kijitora@example.org>... User unknown
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-            push @$rfc822list, $e;
+            $v->{'recipient'} = $1;
+            $v->{'diagnosis'} = $2;
+
+            if( $responding[ $recipients ] ) {
+                # Concatenate the response of the server and error message
+                $v->{'diagnosis'} .= ': '.$responding[$recipients];
+            }
+            $recipients++;
+
+        } elsif( $e =~ /\A[>]{3}[ \t]*([A-Z]{4})[ \t]*/ ) {
+            # >>> RCPT To:<kijitora@example.org>
+            $commandset[ $recipients ] = $1;
+
+        } elsif( $e =~ /\A[<]{3}[ ]+(.+)\z/ ) {
+            # <<< Response
+            # <<< 501 <shironeko@example.co.jp>... no access from mail server [192.0.2.55] which is an open relay.
+            # <<< 550 Requested User Mailbox not found. No such user here.
+            $responding[ $recipients ] = $1;
 
         } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            #    ----- Transcript of session follows -----
-            # While talking to smtp.example.com:
-            # >>> RCPT To:<kijitora@example.org>
-            # <<< 550 <kijitora@example.org>, User Unknown
-            # 550 <kijitora@example.org>... User unknown
-            # 421 example.org (smtp)... Deferred: Connection timed out during user open with example.org
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A\d{3}[ \t]+[<]([^ ]+[@][^ ]+)[>][.]{3}[ \t]*(.+)\z/ ) {
-                # 550 <kijitora@example.org>... User unknown
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $v->{'diagnosis'} = $2;
-
-                if( $responding[ $recipients ] ) {
-                    # Concatenate the response of the server and error message
-                    $v->{'diagnosis'} .= ': '.$responding[$recipients];
-                }
-                $recipients++;
-
-            } elsif( $e =~ /\A[>]{3}[ \t]*([A-Z]{4})[ \t]*/ ) {
-                # >>> RCPT To:<kijitora@example.org>
-                $commandset[ $recipients ] = $1;
-
-            } elsif( $e =~ /\A[<]{3}[ ]+(.+)\z/ ) {
-                # <<< Response
-                # <<< 501 <shironeko@example.co.jp>... no access from mail server [192.0.2.55] which is an open relay.
-                # <<< 550 Requested User Mailbox not found. No such user here.
-                $responding[ $recipients ] = $1;
-
-            } else {
-                # Detect SMTP session error or connection error
-                next if $v->{'sessionerr'};
-                if( $e =~ $MarkingsOf->{'error'} ) {
-                    # ----- Transcript of session follows -----
-                    # ... while talking to mta.example.org.:
-                    $v->{'sessionerr'} = 1;
-                    next;
-                }
-
-                # 421 example.org (smtp)... Deferred: Connection timed out during user open with example.org
-                $anotherset->{'diagnosis'} = $1 if $e =~ /\A\d{3}[ \t]+.+[.]{3}[ \t]*(.+)\z/;
+            # Detect SMTP session error or connection error
+            next if $v->{'sessionerr'};
+            if( $e =~ $MarkingsOf->{'error'} ) {
+                # ----- Transcript of session follows -----
+                # ... while talking to mta.example.org.:
+                $v->{'sessionerr'} = 1;
+                next;
             }
-        } # End of error message part
+
+            # 421 example.org (smtp)... Deferred: Connection timed out during user open with example.org
+            $anotherset->{'diagnosis'} = $1 if $e =~ /\A\d{3}[ \t]+.+[.]{3}[ \t]*(.+)\z/;
+        }
     }
-    return undef unless $readcursor & $Indicators->{'message-rfc822'};
 
     unless( $recipients ) {
         # Get the recipient address from the original message
-        for my $e ( @$rfc822list ) {
+        if( $emailsteak->[1] =~ /^To:[ ]*(.+)/m ) {
             # The value of To: header in the original message
-            next unless $e =~ /^To: (.+)$/;
             $dscontents->[0]->{'recipient'} = Sisimai::Address->s3s4($1);
             $recipients = 1;
-            last;
         }
     }
     return undef unless $recipients;
@@ -178,7 +151,7 @@ sub make {
         next if $e->{'recipient'} =~ /\A[^ ]+[@][^ ]+\z/;
         $e->{'recipient'} = $1 if $e->{'diagnosis'} =~ /[<]([^ ]+[@][^ ]+)[>]/;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -225,7 +198,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Verizon.pm
+++ b/lib/Sisimai/Lhost/Verizon.pm
@@ -229,3 +229,4 @@ Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 This software is distributed under The BSD 2-Clause License.
 
 =cut
+

--- a/lib/Sisimai/Lhost/Verizon.pm
+++ b/lib/Sisimai/Lhost/Verizon.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr/__BOUNDARY_STRING_HERE__/m;
 
 sub description { 'Verizon Wireless: https://www.verizonwireless.com' }
 sub make {
@@ -36,9 +37,7 @@ sub make {
     return undef if $match < 0;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my @hasdivided = split("\n", $$mbody);
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = [];
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $senderaddr = '';    # (String) Sender address in the message body
@@ -51,10 +50,7 @@ sub make {
 
     if( $match == 1 ) {
         # vtext.com
-        $MarkingsOf = {
-            'message' => qr/\AError:[ \t]/,
-            'rfc822'  => qr/\A__BOUNDARY_STRING_HERE__\z/,
-        };
+        $MarkingsOf = { 'message' => qr/\AError:[ \t]/ };
         $MessagesOf = {
             # The attempted recipient address does not exist.
             'userunknown' => ['550 - Requested action not taken: no such user here'],
@@ -63,157 +59,111 @@ sub make {
         if( my $boundary00 = Sisimai::MIME->boundary($mhead->{'content-type'}) ) {
             # Convert to regular expression
             $boundary00 = '--'.$boundary00.'--';
-            $MarkingsOf->{'rfc822'} = qr/\A\Q$boundary00\E\z/;
+            $ReBackbone = qr/^\Q$boundary00\E/m;
         }
 
-        for my $e ( @hasdivided ) {
-            # Read each line between the start of the message and the start of rfc822 part.
+        $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
+        for my $e ( split("\n", $emailsteak->[0]) ) {
+            # Read error messages and delivery status lines from the head of the email
+            # to the previous line of the beginning of the original message.
             unless( $readcursor ) {
                 # Beginning of the bounce message or delivery status part
-                if( $e =~ $MarkingsOf->{'message'} ) {
-                    $readcursor |= $Indicators->{'deliverystatus'};
-                    next;
-                }
+                $readcursor |= $Indicators->{'deliverystatus'} if $e =~ $MarkingsOf->{'message'};
+                next;
             }
+            next unless $readcursor & $Indicators->{'deliverystatus'};
+            next unless length $e;
 
-            unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-                # Beginning of the original message part
-                if( $e =~ $MarkingsOf->{'rfc822'} ) {
-                    $readcursor |= $Indicators->{'message-rfc822'};
-                    next;
-                }
-            }
+            # Message details:
+            #   Subject: Test message
+            #   Sent date: Wed Jun 12 02:21:53 GMT 2013
+            #   MAIL FROM: *******@hg.example.com
+            #   RCPT TO: *****@vtext.com
+            $v = $dscontents->[-1];
 
-            if( $readcursor & $Indicators->{'message-rfc822'} ) {
-                # Inside of the original message part
-                unless( length $e ) {
-                    last if ++$blanklines > 1;
-                    next;
+            if( $e =~ /\A[ \t]+RCPT TO: (.*)\z/ ) {
+                if( $v->{'recipient'} ) {
+                    # There are multiple recipient addresses in the message body.
+                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                    $v = $dscontents->[-1];
                 }
-                push @$rfc822list, $e;
+                $v->{'recipient'} = $1;
+                $recipients++;
+                next;
+
+            } elsif( $e =~ /\A[ \t]+MAIL FROM:[ \t](.+)\z/ ) {
+                #   MAIL FROM: *******@hg.example.com
+                $senderaddr ||= $1;
+
+            } elsif( $e =~ /\A[ \t]+Subject:[ \t](.+)\z/ ) {
+                #   Subject:
+                $subjecttxt ||= $1;
 
             } else {
-                # Error message part
-                next unless $readcursor & $Indicators->{'deliverystatus'};
-                next unless length $e;
-
-                # Message details:
-                #   Subject: Test message
-                #   Sent date: Wed Jun 12 02:21:53 GMT 2013
-                #   MAIL FROM: *******@hg.example.com
-                #   RCPT TO: *****@vtext.com
-                $v = $dscontents->[-1];
-
-                if( $e =~ /\A[ \t]+RCPT TO: (.*)\z/ ) {
-                    if( $v->{'recipient'} ) {
-                        # There are multiple recipient addresses in the message body.
-                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                        $v = $dscontents->[-1];
-                    }
-                    $v->{'recipient'} = $1;
-                    $recipients++;
-                    next;
-
-                } elsif( $e =~ /\A[ \t]+MAIL FROM:[ \t](.+)\z/ ) {
-                    #   MAIL FROM: *******@hg.example.com
-                    $senderaddr ||= $1;
-
-                } elsif( $e =~ /\A[ \t]+Subject:[ \t](.+)\z/ ) {
-                    #   Subject:
-                    $subjecttxt ||= $1;
-
-                } else {
-                    # 550 - Requested action not taken: no such user here
-                    $v->{'diagnosis'} = $e if $e =~ /\A(\d{3})[ \t][-][ \t](.*)\z/;
-                }
-            } # End of error message part
+                # 550 - Requested action not taken: no such user here
+                $v->{'diagnosis'} = $e if $e =~ /\A(\d{3})[ \t][-][ \t](.*)\z/;
+            }
         }
     } else {
         # vzwpix.com
         $StartingOf = { 'message' => ['Message could not be delivered to mobile'] };
-        $MarkingsOf = { 'rfc822'  => qr/\A__BOUNDARY_STRING_HERE__\z/ };
         $MessagesOf = { 'userunknown' => ['No valid recipients for this MM'] };
 
         if( my $boundary00 = Sisimai::MIME->boundary($mhead->{'content-type'}) ) {
             # Convert to regular expression
             $boundary00 = '--'.$boundary00.'--';
-            $MarkingsOf->{'rfc822'} = qr/\A\Q$boundary00\E\z/;
+            $ReBackbone = qr/^\Q$boundary00\E/m;
         }
 
-        for my $e ( @hasdivided ) {
-            # Read each line between the start of the message and the start of rfc822 part.
+        $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
+        for my $e ( split("\n", $emailsteak->[0]) ) {
+            # Read error messages and delivery status lines from the head of the email
+            # to the previous line of the beginning of the original message.
             unless( $readcursor ) {
                 # Beginning of the bounce message or delivery status part
-                if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                    $readcursor |= $Indicators->{'deliverystatus'};
-                    next;
-                }
+                $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+                next;
             }
+            next unless $readcursor & $Indicators->{'deliverystatus'};
+            next unless length $e;
 
-            unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-                # Beginning of the original message part
-                if( $e =~ $MarkingsOf->{'rfc822'} ) {
-                    $readcursor |= $Indicators->{'message-rfc822'};
-                    next;
-                }
-            }
+            # Original Message:
+            # From: kijitora <kijitora@example.jp>
+            # To: 0000000000@vzwpix.com
+            # Subject: test for bounce
+            # Date:  Wed, 20 Jun 2013 10:29:52 +0000
+            $v = $dscontents->[-1];
 
-            if( $readcursor & $Indicators->{'message-rfc822'} ) {
-                # Inside of the original message part
-                unless( length $e ) {
-                    last if ++$blanklines > 1;
-                    next;
+            if( $e =~ /\ATo:[ \t]+(.*)\z/ ) {
+                if( $v->{'recipient'} ) {
+                    # There are multiple recipient addresses in the message body.
+                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                    $v = $dscontents->[-1];
                 }
-                push @$rfc822list, $e;
+                $v->{'recipient'} = Sisimai::Address->s3s4($1);
+                $recipients++;
+                next;
+
+            } elsif( $e =~ /\AFrom:[ \t](.+)\z/ ) {
+                # From: kijitora <kijitora@example.jp>
+                $senderaddr ||= Sisimai::Address->s3s4($1);
+
+            } elsif( $e =~ /\ASubject:[ \t](.+)\z/ ) {
+                #   Subject:
+                $subjecttxt ||= $1;
 
             } else {
-                # Error message part
-                next unless $readcursor & $Indicators->{'deliverystatus'};
-                next unless length $e;
-
-                # Original Message:
-                # From: kijitora <kijitora@example.jp>
-                # To: 0000000000@vzwpix.com
-                # Subject: test for bounce
-                # Date:  Wed, 20 Jun 2013 10:29:52 +0000
-                $v = $dscontents->[-1];
-
-                if( $e =~ /\ATo:[ \t]+(.*)\z/ ) {
-                    if( $v->{'recipient'} ) {
-                        # There are multiple recipient addresses in the message body.
-                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                        $v = $dscontents->[-1];
-                    }
-                    $v->{'recipient'} = Sisimai::Address->s3s4($1);
-                    $recipients++;
-                    next;
-
-                } elsif( $e =~ /\AFrom:[ \t](.+)\z/ ) {
-                    # From: kijitora <kijitora@example.jp>
-                    $senderaddr ||= Sisimai::Address->s3s4($1);
-
-                } elsif( $e =~ /\ASubject:[ \t](.+)\z/ ) {
-                    #   Subject:
-                    $subjecttxt ||= $1;
-
-                } else {
-                    # Message could not be delivered to mobile.
-                    # Error: No valid recipients for this MM
-                    $v->{'diagnosis'} = $e if $e =~ /\AError:[ \t]+(.+)\z/;
-                }
-            } # End of error message part
+                # Message could not be delivered to mobile.
+                # Error: No valid recipients for this MM
+                $v->{'diagnosis'} = $e if $e =~ /\AError:[ \t]+(.+)\z/;
+            }
         }
     }
     return undef unless $recipients;
 
-    if( ! grep { index($_, 'From: ') == 0 } @$rfc822list ) {
-        # Set the value of "MAIL FROM:" or "From:"
-        push @$rfc822list, 'From: '.$senderaddr;
-
-    } elsif( ! grep { index($_, 'Subject: ') == 0 } @$rfc822list ) {
-        # Set the value of "Subject"
-        push @$rfc822list, 'Subject: '.$subjecttxt;
-    }
+    # Set the value of "MAIL FROM:" and "From:"
+    $emailsteak->[1] .= sprintf("From: %s\n", $senderaddr) unless $emailsteak->[1] =~ /^From: /m;
+    $emailsteak->[1] .= sprintf("Subject: %s\n", $subjecttxt) unless $emailsteak->[1] =~ /^Subject: /m;
 
     for my $e ( @$dscontents ) {
         $e->{'agent'}     = __PACKAGE__->smtpagent;
@@ -226,7 +176,7 @@ sub make {
             last;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -272,7 +222,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X4.pm
+++ b/lib/Sisimai/Lhost/X4.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'rfc822' => ['--- Below this line is a copy of the message.', '--- Original message follows.'],
-    'error'  => ['Remote host said:'],
-};
+my $ReBackbone = qr/^---[ ](?:Below this line is a copy of the message|Original message follows)[.]/m;
+my $StartingOf = { 'error'  => ['Remote host said:'] };
 my $MarkingsOf = {
     #  qmail-remote.c:248|    if (code >= 500) {
     #  qmail-remote.c:249|      out("h"); outhost(); out(" does not like recipient.\n");
@@ -151,70 +149,47 @@ sub make {
     return undef unless $match;
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
-            if( $e =~ $MarkingsOf->{'message'} ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            # Beginning of the bounce message or message/delivery-status part
+            $readcursor |= $Indicators->{'deliverystatus'} if $e =~ $MarkingsOf->{'message'};
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ||
-                index($e, $StartingOf->{'rfc822'}->[1]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # <kijitora@example.jp>:
+        # 192.0.2.153 does not like recipient.
+        # Remote host said: 550 5.1.1 <kijitora@example.jp>... User Unknown
+        # Giving up on 192.0.2.153.
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
+        if( $e =~ /\A(?:To[ ]*:)?[<](.+[@].+)[>]:[ \t]*\z/ ) {
             # <kijitora@example.jp>:
-            # 192.0.2.153 does not like recipient.
-            # Remote host said: 550 5.1.1 <kijitora@example.jp>... User Unknown
-            # Giving up on 192.0.2.153.
-            $v = $dscontents->[-1];
-
-            if( $e =~ /\A(?:To[ ]*:)?[<](.+[@].+)[>]:[ \t]*\z/ ) {
-                # <kijitora@example.jp>:
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $recipients++;
-
-            } elsif( scalar @$dscontents == $recipients ) {
-                # Append error message
-                next unless length $e;
-                $v->{'diagnosis'} .= $e.' ';
-                $v->{'alterrors'}  = $e if index($e, $StartingOf->{'error'}->[0]) == 0;
-
-                next if $v->{'rhost'};
-                $v->{'rhost'} = $1 if $e =~ $ReHost;
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
             }
-        } # End of error message part
+            $v->{'recipient'} = $1;
+            $recipients++;
+
+        } elsif( scalar @$dscontents == $recipients ) {
+            # Append error message
+            next unless length $e;
+            $v->{'diagnosis'} .= $e.' ';
+            $v->{'alterrors'}  = $e if index($e, $StartingOf->{'error'}->[0]) == 0;
+
+            next if $v->{'rhost'};
+            $v->{'rhost'} = $1 if $e =~ $ReHost;
+        }
     }
     return undef unless $recipients;
 
@@ -284,7 +259,7 @@ sub make {
         $e->{'command'} ||= '';
         $e->{'agent'}  = __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -331,7 +306,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X5.pm
+++ b/lib/Sisimai/Lhost/X5.pm
@@ -73,7 +73,6 @@ sub make {
         next unless length $e;
 
         $v = $dscontents->[-1];
-
         if( Sisimai::RFC1894->match($e) ) {
             # $e matched with any field defined in RFC3464
             next unless my $o = Sisimai::RFC1894->field($e);

--- a/lib/Sisimai/Lhost/Yandex.pm
+++ b/lib/Sisimai/Lhost/Yandex.pm
@@ -5,10 +5,8 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
-my $StartingOf = {
-    'message' => ['This is the mail system at host yandex.ru.'],
-    'rfc822'  => ['Content-Type: message/rfc822'],
-};
+my $ReBackbone = qr|^Content-Type:[ ]message/rfc822|m;
+my $StartingOf = { 'message' => ['This is the mail system at host yandex.ru.'] };
 
 # X-Yandex-Front: mxback1h.mail.yandex.net
 # X-Yandex-TimeMark: 1417885948
@@ -44,101 +42,79 @@ sub make {
     my $permessage = {};    # (Hash) Store values of each Per-Message field
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my @commandset;         # (Array) ``in reply to * command'' list
     my $v = undef;
     my $p = '';
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
             # Beginning of the bounce message or message/delivery-status part
-            if( index($e, $StartingOf->{'message'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'deliverystatus'};
-                next;
-            }
+            $readcursor |= $Indicators->{'deliverystatus'} if index($e, $StartingOf->{'message'}->[0]) == 0;
+            next;
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part(message/rfc822)
-            if( index($e, $StartingOf->{'rfc822'}->[0]) == 0 ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        if( my $f = Sisimai::RFC1894->match($e) ) {
+            # $e matched with any field defined in RFC3464
+            next unless my $o = Sisimai::RFC1894->field($e);
+            $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # message/rfc822 OR text/rfc822-headers part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # message/delivery-status part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            if( my $f = Sisimai::RFC1894->match($e) ) {
-                # $e matched with any field defined in RFC3464
-                next unless my $o = Sisimai::RFC1894->field($e);
-                $v = $dscontents->[-1];
-
-                if( $o->[-1] eq 'addr' ) {
+            if( $o->[-1] eq 'addr' ) {
+                # Final-Recipient: rfc822; kijitora@example.jp
+                # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                if( $o->[0] eq 'final-recipient' ) {
                     # Final-Recipient: rfc822; kijitora@example.jp
-                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                    if( $o->[0] eq 'final-recipient' ) {
-                        # Final-Recipient: rfc822; kijitora@example.jp
-                        if( $v->{'recipient'} ) {
-                            # There are multiple recipient addresses in the message body.
-                            push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                            $v = $dscontents->[-1];
-                        }
-                        $v->{'recipient'} = $o->[2];
-                        $recipients++;
-
-                    } else {
-                        # X-Actual-Recipient: rfc822; kijitora@example.co.jp
-                        $v->{'alias'} = $o->[2];
+                    if( $v->{'recipient'} ) {
+                        # There are multiple recipient addresses in the message body.
+                        push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                        $v = $dscontents->[-1];
                     }
-                } elsif( $o->[-1] eq 'code' ) {
-                    # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
-                    $v->{'spec'} = $o->[1];
-                    $v->{'diagnosis'} = $o->[2];
+                    $v->{'recipient'} = $o->[2];
+                    $recipients++;
 
                 } else {
-                    # Other DSN fields defined in RFC3464
-                    next unless exists $fieldtable->{ $o->[0] };
-                    $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
-
-                    next unless $f == 1;
-                    $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
+                    # X-Actual-Recipient: rfc822; kijitora@example.co.jp
+                    $v->{'alias'} = $o->[2];
                 }
+            } elsif( $o->[-1] eq 'code' ) {
+                # Diagnostic-Code: SMTP; 550 5.1.1 <userunknown@example.jp>... User Unknown
+                $v->{'spec'} = $o->[1];
+                $v->{'diagnosis'} = $o->[2];
+
             } else {
-                # The line does not begin with a DSN field defined in RFC3464
-                # <kijitora@example.jp>: host mx.example.jp[192.0.2.153] said: 550
-                #    5.1.1 <kijitora@example.jp>... User Unknown (in reply to RCPT TO
-                #    command)
-                if( $e =~ /[ \t][(]in reply to .*([A-Z]{4}).*/ ) {
-                    # 5.1.1 <userunknown@example.co.jp>... User Unknown (in reply to RCPT TO
-                    push @commandset, $1;
+                # Other DSN fields defined in RFC3464
+                next unless exists $fieldtable->{ $o->[0] };
+                $v->{ $fieldtable->{ $o->[0] } } = $o->[2];
 
-                } elsif( $e =~ /([A-Z]{4})[ \t]*.*command[)]\z/ ) {
-                    # to MAIL command)
-                    push @commandset, $1;
-
-                } else {
-                    # Continued line of the value of Diagnostic-Code field
-                    next unless index($p, 'Diagnostic-Code:') == 0;
-                    next unless $e =~ /\A[ \t]+(.+)\z/;
-                    $v->{'diagnosis'} .= ' '.$1;
-                }
+                next unless $f == 1;
+                $permessage->{ $fieldtable->{ $o->[0] } } = $o->[2];
             }
-        } # End of message/delivery-status
+        } else {
+            # The line does not begin with a DSN field defined in RFC3464
+            # <kijitora@example.jp>: host mx.example.jp[192.0.2.153] said: 550
+            #    5.1.1 <kijitora@example.jp>... User Unknown (in reply to RCPT TO
+            #    command)
+            if( $e =~ /[ \t][(]in reply to .*([A-Z]{4}).*/ ) {
+                # 5.1.1 <userunknown@example.co.jp>... User Unknown (in reply to RCPT TO
+                push @commandset, $1;
+
+            } elsif( $e =~ /([A-Z]{4})[ \t]*.*command[)]\z/ ) {
+                # to MAIL command)
+                push @commandset, $1;
+
+            } else {
+                # Continued line of the value of Diagnostic-Code field
+                next unless index($p, 'Diagnostic-Code:') == 0;
+                next unless $e =~ /\A[ \t]+(.+)\z/;
+                $v->{'diagnosis'} .= ' '.$1;
+            }
+        }
     } continue {
         # Save the current line for the next loop
         $p = $e;
@@ -154,7 +130,7 @@ sub make {
         $e->{'diagnosis'} =  Sisimai::String->sweep($e->{'diagnosis'});
         $e->{'agent'}     =  __PACKAGE__->smtpagent;
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -200,7 +176,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/mFILTER.pm
+++ b/lib/Sisimai/Lhost/mFILTER.pm
@@ -5,9 +5,9 @@ use strict;
 use warnings;
 
 my $Indicators = __PACKAGE__->INDICATORS;
+my $ReBackbone = qr/^-------original[ ](?:message|mail[ ]info)/m;
 my $StartingOf = {
     'command'  => ['-------SMTP command'],
-    'rfc822'   => ['-------original message', '-------original mail info'],
     'error'    => ['-------server message'],
 };
 my $MarkingsOf = { 'message' => qr/\A[^ ]+[@][^ ]+[.][a-zA-Z]+\z/ };
@@ -38,91 +38,71 @@ sub make {
     return undef unless $mhead->{'subject'}  eq 'failure notice';
 
     my $dscontents = [__PACKAGE__->DELIVERYSTATUS];
-    my $rfc822list = [];    # (Array) Each line in message/rfc822 part string
-    my $blanklines = 0;     # (Integer) The number of blank lines
+    my $emailsteak = Sisimai::RFC5322->fillet($mbody, $ReBackbone);
     my $readcursor = 0;     # (Integer) Points the current cursor position
     my $recipients = 0;     # (Integer) The number of 'Final-Recipient' header
     my $markingset = { 'diagnosis' => 0, 'command' => 0 };
     my $v = undef;
 
-    for my $e ( split("\n", $$mbody) ) {
-        # Read each line between the start of the message and the start of rfc822 part.
+    for my $e ( split("\n", $emailsteak->[0]) ) {
+        # Read error messages and delivery status lines from the head of the email
+        # to the previous line of the beginning of the original message.
         unless( $readcursor ) {
-            # Beginning of the bounce message or delivery status part
+            # Beginning of the bounce message or message/delivery-status part
             $readcursor |= $Indicators->{'deliverystatus'} if $e =~ $MarkingsOf->{'message'};
         }
+        next unless $readcursor & $Indicators->{'deliverystatus'};
+        next unless length $e;
 
-        unless( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Beginning of the original message part
-            if( $e eq $StartingOf->{'rfc822'}->[0] || $e eq $StartingOf->{'rfc822'}->[1] ) {
-                $readcursor |= $Indicators->{'message-rfc822'};
-                next;
-            }
-        }
+        # このメールは「m-FILTER」が自動的に生成して送信しています。
+        # メールサーバーとの通信中、下記の理由により
+        # このメールは送信できませんでした。
+        #
+        # 以下のメールアドレスへの送信に失敗しました。
+        # kijitora@example.jp
+        #
+        #
+        # -------server message
+        # 550 5.1.1 unknown user <kijitora@example.jp>
+        #
+        # -------SMTP command
+        # DATA
+        #
+        # -------original message
+        $v = $dscontents->[-1];
 
-        if( $readcursor & $Indicators->{'message-rfc822'} ) {
-            # Inside of the original message part
-            unless( length $e ) {
-                last if ++$blanklines > 1;
-                next;
-            }
-            push @$rfc822list, $e;
-
-        } else {
-            # Error message part
-            next unless $readcursor & $Indicators->{'deliverystatus'};
-            next unless length $e;
-
-            # このメールは「m-FILTER」が自動的に生成して送信しています。
-            # メールサーバーとの通信中、下記の理由により
-            # このメールは送信できませんでした。
-            #
+        if( $e =~ /\A([^ ]+[@][^ ]+)\z/ ) {
             # 以下のメールアドレスへの送信に失敗しました。
             # kijitora@example.jp
-            #
-            #
-            # -------server message
-            # 550 5.1.1 unknown user <kijitora@example.jp>
-            #
+            if( $v->{'recipient'} ) {
+                # There are multiple recipient addresses in the message body.
+                push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
+                $v = $dscontents->[-1];
+            }
+            $v->{'recipient'} = $1;
+            $recipients++;
+
+        } elsif( $e =~ /\A[A-Z]{4}/ ) {
             # -------SMTP command
             # DATA
-            #
-            # -------original message
-            $v = $dscontents->[-1];
+            next if $v->{'command'};
+            $v->{'command'} = $e if $markingset->{'command'};
 
-            if( $e =~ /\A([^ ]+[@][^ ]+)\z/ ) {
-                # 以下のメールアドレスへの送信に失敗しました。
-                # kijitora@example.jp
-                if( $v->{'recipient'} ) {
-                    # There are multiple recipient addresses in the message body.
-                    push @$dscontents, __PACKAGE__->DELIVERYSTATUS;
-                    $v = $dscontents->[-1];
-                }
-                $v->{'recipient'} = $1;
-                $recipients++;
+        } else {
+            # Get error message and SMTP command
+            if( $e eq $StartingOf->{'error'}->[0] ) {
+                # -------server message
+                $markingset->{'diagnosis'} = 1;
 
-            } elsif( $e =~ /\A[A-Z]{4}/ ) {
+            } elsif( $e eq $StartingOf->{'command'}->[0] ) {
                 # -------SMTP command
-                # DATA
-                next if $v->{'command'};
-                $v->{'command'} = $e if $markingset->{'command'};
+                $markingset->{'command'} = 1;
 
             } else {
-                # Get error message and SMTP command
-                if( $e eq $StartingOf->{'error'}->[0] ) {
-                    # -------server message
-                    $markingset->{'diagnosis'} = 1;
-
-                } elsif( $e eq $StartingOf->{'command'}->[0] ) {
-                    # -------SMTP command
-                    $markingset->{'command'} = 1;
-
-                } else {
-                    # 550 5.1.1 unknown user <kijitora@example.jp>
-                    next if index($e, '-') == 0;
-                    next if $v->{'diagnosis'};
-                    $v->{'diagnosis'} = $e;
-                }
+                # 550 5.1.1 unknown user <kijitora@example.jp>
+                next if index($e, '-') == 0;
+                next if $v->{'diagnosis'};
+                $v->{'diagnosis'} = $e;
             }
         } # End of error message part
     }
@@ -144,7 +124,7 @@ sub make {
             $e->{'rhost'} = $ee;
         }
     }
-    return { 'ds' => $dscontents, 'rfc822' => ${ Sisimai::RFC5322->weedout($rfc822list) } };
+    return { 'ds' => $dscontents, 'rfc822' => $emailsteak->[1] };
 }
 
 1;
@@ -191,7 +171,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -217,14 +217,14 @@ sub headers {
     my $currheader = '';
     my $allheaders = {};
     my $structured = {};
-    my @hasdivided = split("\n", $$heads);
+    my @headslices = split("\n", $$heads);
 
     map { $allheaders->{ $_ } = 1 } (@HeaderList, @RFC3834Set, keys %$ExtHeaders);
     map { $allheaders->{ lc $_ } = 1 } @$field if scalar @$field;
     map { $structured->{ $_ } = undef } @HeaderList;
     map { $structured->{ $_ } = [] } keys %$IsMultiple;
 
-    SPLIT_HEADERS: while( my $e = shift @hasdivided ) {
+    SPLIT_HEADERS: while( my $e = shift @headslices ) {
         # Convert email headers to hash
         if( $e =~ /\A[ \t]+(.+)\z/ ) {
             # Continued (foled) header value from the previous line
@@ -631,7 +631,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC3464.pm
+++ b/lib/Sisimai/RFC3464.pm
@@ -16,7 +16,10 @@ my $MarkingsOf = {
              )
         |the[ ]original[ ]message[ ]was[ ]received[ ]at[ ]
         |this[ ]report[ ]relates[ ]to[ ]your[ ]message
-        |your[ ]message[ ]was[ ]not[ ]delivered[ ]to[ ]the[ ]following[ ]recipients
+        |your[ ]message[ ](?:
+            could[ ]not[ ]be[ ]delivered
+           |was[ ]not[ ]delivered[ ]to[ ]the[ ]following[ ]recipients
+           )
         )
     }x,
     'error'  => qr/\A(?:[45]\d\d[ \t]+|[<][^@]+[@][^@]+[>]:?[ \t]+)/,
@@ -505,7 +508,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC3464.pm
+++ b/lib/Sisimai/RFC3464.pm
@@ -417,19 +417,15 @@ sub make {
     } # END OF BODY_PARSER_FOR_FALLBACK
     return undef unless $itisbounce;
 
-    unless( $recipients ) {
-        # Try to get a recipient address from email headers
-        if( $rfc822text =~ /^To:[ ]*(.+)/m ) {
-            # Check To: header in the original message
-            if( my $r = Sisimai::Address->find($1, 1) ) {
-                next unless scalar @$r;
-                push @$dscontents, Sisimai::Lhost->DELIVERYSTATUS if scalar(@$dscontents) == $recipients;
-
-                my $b = $dscontents->[-1];
-                $b->{'recipient'} = $r->[0]->{'address'};
-                $b->{'agent'} = __PACKAGE__->smtpagent.'::Fallback';
-                $recipients++;
-            }
+    if( $recipients == 0 && $rfc822text =~ /^To:[ ]*(.+)/m ) {
+        # Try to get a recipient address from "To:" header of the original message
+        if( my $r = Sisimai::Address->find($1, 1) ) {
+            # Found a recipient address
+            push @$dscontents, Sisimai::Lhost->DELIVERYSTATUS if scalar(@$dscontents) == $recipients;
+            my $b = $dscontents->[-1];
+            $b->{'recipient'} = $r->[0]->{'address'};
+            $b->{'agent'} = __PACKAGE__->smtpagent.'::Fallback';
+            $recipients++;
         }
     }
     return undef unless $recipients;

--- a/lib/Sisimai/RFC3464.pm
+++ b/lib/Sisimai/RFC3464.pm
@@ -25,7 +25,7 @@ my $MarkingsOf = {
     'error'  => qr/\A(?:[45]\d\d[ \t]+|[<][^@]+[@][^@]+[>]:?[ \t]+)/,
     'rfc822' => qr{\A(?>
          content-type:[ ]*(?:message/rfc822|text/rfc822-headers)
-        |return-path:[ ]*[<].+[>]\z
+        |return-path:[ ]*[<].+[>]
         )\z
     }x,
 };

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -202,40 +202,6 @@ sub fillet {
     return [$a, $b];
 }
 
-sub weedout {
-    # Weed out rfc822/message header fields excepct necessary fields
-    # @param    [Array] argv1  each line divided message/rc822 part
-    # @return   [String]       Selected fields
-    my $class = shift;
-    my $argv1 = shift // return undef;
-    return undef unless ref $argv1 eq 'ARRAY';
-
-    my $rfc822next = { 'from' => 0, 'to' => 0, 'subject' => 0 };
-    my $rfc822part = '';    # (String) message/rfc822-headers part
-    my $previousfn = '';    # (String) Previous field name
-
-    for my $e ( @$argv1 ) {
-        # After "message/rfc822"
-        if( $e =~ /\A[ \t]+/ ) {
-            # Continued line from the previous line
-            next if $rfc822next->{ $previousfn };
-            $rfc822part .= $e."\n" if exists $LONGHEADERS->{ $previousfn };
-
-        } else {
-            # Get required headers only
-            my($lhs, $rhs) = split(/:[ ]*/, $e, 2);
-            next unless $lhs = lc($lhs || '');
-
-            $previousfn = '';
-            next unless exists $HEADERINDEX->{ $lhs };
-
-            $previousfn  = $lhs;
-            $rfc822part .= $e."\n";
-        }
-    }
-    return \$rfc822part;
-}
-
 1;
 __END__
 
@@ -302,25 +268,6 @@ header.
         'mx.example.org',
         'mx.example.jp'
     ];
-
-=head2 C<B<weedout(I<Array>)>>
-
-C<weedout()> returns string including only necessary fields from message/rfc822
-part. This method is called from only Sisimai::Lhost::* modules.
-
-    my $v = <<'EOM';
-    From: postmaster@nyaan.example.org
-    To: kijitora@example.jp
-    Subject: Delivery failure
-    X-Mailer: Neko mailer v2.22
-    EOM
-
-    my $r = Sisimai::RFC5322->weedout([split("\n", $v)]);
-    print $$r;
-
-    From: postmaster@nyaan.example.org
-    To: kijitora@example.jp
-    Subject: Delivery failure
 
 =head1 AUTHOR
 

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -269,13 +269,29 @@ header.
         'mx.example.jp'
     ];
 
+=head2 C<B<fillet(I<String>, I<RegExp>)>>
+
+C<fillet()> returns array reference which include error message lines of given
+message body and the original message part splitted by the 2nd argument.
+
+    my $v = 'Error message here
+    Content-Type: message/rfc822
+    Return-Path: <neko@libsisimai.org>';
+    my $r = Sisimai::RFC5322->fillet(\$v, qr|^Content-Type:[ ]message/rfc822|m);
+
+    warn Dumper $r;
+    $VAR1 = [
+        'Error message here',
+        'Return-Path: <neko@libsisimai.org>';
+    ];
+
 =head1 AUTHOR
 
 azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2019 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -179,6 +179,29 @@ sub received {
     return $hosts;
 }
 
+sub fillet {
+    # Split given entire message body into error message lines and the original
+    # message part only include email headers
+    # @param    [String] mbody  Entire message body
+    # @param    [Regexp] regex  Regular expression of the message/rfc822 or the
+    #                           beginning of the original message part
+    # @return   [Array]         [Error message lines, The original message]
+    # @since    v4.25.5
+    my $class = shift;
+    my $mbody = shift || return undef;
+    my $regex = shift || return undef;
+
+    my ($a, $b) = split($regex, $$mbody, 2); $b ||= '';
+    if( length $b ) {
+        # Remove blank lines, the message body of the original message,
+        # and append "\n" at the end of the original message headers
+        $b  =~ s/\A[\r\n\s]+//m;   # Remove leading blank lines
+        $b  =~ s/\n\n.+\z//ms;     # Remove text after the first blank line
+        $b  .= "\n" unless $b =~ /\n\z/;
+    }
+    return [$a, $b];
+}
+
 sub weedout {
     # Weed out rfc822/message header fields excepct necessary fields
     # @param    [Array] argv1  each line divided message/rc822 part

--- a/t/031-rfc5322.t
+++ b/t/031-rfc5322.t
@@ -7,8 +7,7 @@ my $PackageName = 'Sisimai::RFC5322';
 my $MethodNames = {
     'class' => [
         'HEADERFIELDS', 'LONGFIELDS',
-        'is_emailaddress', 'is_mailerdaemon', 'received',
-        'fillet', 'weedout',
+        'is_emailaddress', 'is_mailerdaemon', 'received', 'fillet',
     ],
     'object' => [],
 };
@@ -129,32 +128,6 @@ MAKE_TEST: {
             ok $f =~ qr/\A[-.0-9A-Za-z]+\z/, 'Regular expression';
         }
     }
-
-    my $rfc822text = <<'EOR';
-Return-Path: <shironeko@mx.example.co.jp>
-Received: from mx.example.co.jp (localhost [127.0.0.1])
-	by mx.example.co.jp (8.13.9/8.13.1) with ESMTP id fffff000000001
-	for <kijitora@example.net>; Thu, 9 Apr 2014 23:34:45 +0900
-Received: (from shironeko@localhost)
-	by mx.example.co.jp (8.13.9/8.13.1/Submit) id fff0000000003
-	for kijitora@example.net; Thu, 9 Apr 2014 23:34:45 +0900
-Date: Thu, 9 Apr 2014 23:34:45 +0900
-Message-Id: <0000000011111.fff0000000003@mx.example.co.jp>
-Content-Type: text/plain
-MIME-Version: 1.0
-From: Shironeko <shironeko@example.co.jp>
-To: Kijitora <shironeko@example.co.jp>
-Subject: Nyaaaan
-
-Nyaaan
-EOR
-    my $rfc822part = Sisimai::RFC5322->weedout([split("\n", $rfc822text)]);
-    isa_ok $rfc822part, 'SCALAR';
-    ok length $$rfc822part;
-    like $$rfc822part, qr/^From:/m;
-    like $$rfc822part, qr/^Date:/m;
-    unlike $$rfc822part, qr/^MIME-Version:/m;
-    unlike $$rfc822part, qr/^Received:/m;
 
     my $rfc822body = <<'EOB';
 This is a MIME-encapsulated message

--- a/t/698-rfc3464.t
+++ b/t/698-rfc3464.t
@@ -19,7 +19,7 @@ my $isexpected = [
     { 'n' => '26', 's' => qr/\A5[.]1[.]1\z/,      'r' => qr/userunknown/,   'a' => qr/RFC3464/, 'b' => qr/\A0\z/ },
     { 'n' => '28', 's' => qr/\A2[.]1[.]5\z/,      'r' => qr/delivered/,     'a' => qr/RFC3464/, 'b' => qr/\A-1\z/ },
     { 'n' => '29', 's' => qr/\A5[.]5[.]0\z/,      'r' => qr/syntaxerror/,   'a' => qr/RFC3464/, 'b' => qr/\A1\z/ },
-    { 'n' => '34', 's' => qr/\A5[.]0[.]\d+\z/,    'r' => qr/networkerror/,  'a' => qr/RFC3464/, 'b' => qr/\A1\z/ },
+    { 'n' => '34', 's' => qr/\A4[.]4[.]1\z/,      'r' => qr/networkerror/,  'a' => qr/RFC3464/, 'b' => qr/\A1\z/ },
     { 'n' => '35', 's' => qr/\A[45][.]0[.]0\z/,   'r' => qr/(?:filtered|expired|rejected)/,'a' => qr/RFC3464/, 'b' => qr/\A1\z/ },
     { 'n' => '36', 's' => qr/\A4[.]0[.]0\z/,      'r' => qr/expired/,       'a' => qr/RFC3464/, 'b' => qr/\A1\z/ },
     { 'n' => '37', 's' => qr/\A5[.]0[.]\d+\z/,    'r' => qr/hostunknown/,   'a' => qr/RFC3464/, 'b' => qr/\A0\z/ },

--- a/xt/644-lhost-sendmail.t
+++ b/xt/644-lhost-sendmail.t
@@ -185,7 +185,6 @@ my $isexpected = [
     { 'n' => '01177', 'r' => qr/mailererror/    },
     { 'n' => '01178', 'r' => qr/hostunknown/    },
     { 'n' => '01179', 'r' => qr/userunknown/    },
-    { 'n' => '01180', 'r' => qr/userunknown/    },
     { 'n' => '01181', 'r' => qr/mesgtoobig/     },
     { 'n' => '01182', 'r' => qr/userunknown/    },
     { 'n' => '01183', 'r' => qr/suspend/        },
@@ -224,6 +223,7 @@ my $isexpected = [
     { 'n' => '01216', 'r' => qr/userunknown/    },
     { 'n' => '01217', 'r' => qr/blocked/        },
     { 'n' => '01218', 'r' => qr/blocked/        },
+    { 'n' => '01219', 'r' => qr/userunknown/    },
 ];
 
 plan 'skip_all', sprintf("%s not found", $samplepath) unless -d $samplepath;


### PR DESCRIPTION
- #354
- Divide a message body into message/delivery-status part and message/rfc822 part
- About 30% faster than v4.25.4p6
- Decrease about 15% at lines of code
- Sisimai::RFC5322->fillet divides entire message body