### PR TITLE
Filed param has been removed

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,12 @@ v4.25.5p9
     - The MTA module to be loaded at first is decided by the first 2 words of
       each bounce mail subject, is defined at `$Subject` in `Sisimai::Order`
     - Some variables are replaced with `state`
+  - Each `field` parameter has been removed from the following methods because 
+    Sisimai detect all the email header fields by `Sisimai::Message->makemap()`
+    without having to specify field names at `field` parameter
+    - `Sisimai->make`
+    - `Sisimai::Message->new`
+    - `Sisimai::Message->make`
   - Code improvement for `require` statement before calling `match()` method of
     some modules defined in `$PreMatches` at `Sisimai::Reason::UserUnknown`
   - #369 Remove the following unused methods:

--- a/README-JA.md
+++ b/README-JA.md
@@ -183,9 +183,8 @@ my $callbackto = sub {
     $caught->{'x-mailer'} = $emdata->{'headers'}->{'x-mailer'} || '';
     return $caught;
 };
-my $list = ['X-Mailer'];
-my $data = Sisimai->make('/path/to/mbox', 'hook' => $callbackto, 'field' => $list);
-my $json = Sisimai->dump('/path/to/mbox', 'hook' => $callbackto, 'field' => $list);
+my $data = Sisimai->make('/path/to/mbox', 'hook' => $callbackto);
+my $json = Sisimai->dump('/path/to/mbox', 'hook' => $callbackto);
 
 print $data->[0]->catch->{'x-mailer'};    # Apple Mail (2.1283)
 ```

--- a/README.md
+++ b/README.md
@@ -187,9 +187,8 @@ my $callbackto = sub {
     $caught->{'x-mailer'} = $emdata->{'headers'}->{'x-mailer'} || '';
     return $caught;
 };
-my $list = ['X-Mailer'];
-my $data = Sisimai->make('/path/to/mbox', 'hook' => $callbackto, 'field' => $list);
-my $json = Sisimai->dump('/path/to/mbox', 'hook' => $callbackto, 'field' => $list);
+my $data = Sisimai->make('/path/to/mbox', 'hook' => $callbackto);
+my $json = Sisimai->dump('/path/to/mbox', 'hook' => $callbackto);
 
 print $data->[0]->catch->{'x-mailer'};    # Apple Mail (2.1283)
 ```

--- a/lib/Sisimai.pm
+++ b/lib/Sisimai.pm
@@ -16,7 +16,6 @@ sub make {
     # @param         [Hash]    argv1      Parser options
     # @options argv1 [Integer] delivered  1 = Including "delivered" reason
     # @options argv1 [Code]    hook       Code reference to a callback method
-    # @options argv1 [Array]   field      Email header names to be captured
     # @return        [Array]              Parsed objects
     # @return        [Undef]              Undef if the argument was wrong or an empty array
     my $class = shift;
@@ -24,8 +23,6 @@ sub make {
     die ' ***error: wrong number of arguments' if scalar @_ % 2;
 
     my $argv1 = { @_ };
-    my $field = $argv1->{'field'} || [];
-    die ' ***error: "field" accepts an array reference only' if ref $field ne 'ARRAY';
 
     require Sisimai::Data;
     require Sisimai::Message;
@@ -36,7 +33,7 @@ sub make {
 
     while( my $r = $mail->read ) {
         # Read and parse each mail file
-        my $p = { 'data'  => $r, 'hook' => $argv1->{'hook'}, 'field' => $field };
+        my $p = { 'data'  => $r, 'hook' => $argv1->{'hook'} };
         next unless my $mesg = Sisimai::Message->new(%$p);
 
         my $data = Sisimai::Data->make('data' => $mesg, 'delivered' => $argv1->{'delivered'});
@@ -244,7 +241,6 @@ method like the following codes:
     my $message = Sisimai::Message->new(
         'data' => $mailtxt,
         'hook' => $cmethod,
-        'field' => ['X-Mailer', 'Precedence']
     );
     print $message->catch->{'x-mailer'};    # Apple Mail (2.1283)
     print $message->catch->{'queue-id'};    # 2DAEB222022E

--- a/lib/Sisimai.pm
+++ b/lib/Sisimai.pm
@@ -19,9 +19,7 @@ sub make {
     # @return        [Array]              Parsed objects
     # @return        [Undef]              Undef if the argument was wrong or an empty array
     my $class = shift;
-    my $argv0 = shift // return undef;
-    die ' ***error: wrong number of arguments' if scalar @_ % 2;
-
+    my $argv0 = shift // return undef; die ' ***error: wrong number of arguments' if scalar @_ % 2;
     my $argv1 = { @_ };
 
     require Sisimai::Data;
@@ -30,7 +28,6 @@ sub make {
 
     my $list = [];
     my $mail = Sisimai::Mail->new($argv0) || return undef;
-
     while( my $r = $mail->read ) {
         # Read and parse each mail file
         my $p = { 'data'  => $r, 'hook' => $argv1->{'hook'} };
@@ -53,9 +50,7 @@ sub dump {
     # @options argv1 [Code]    hook       Code reference to a callback method
     # @return        [String]             Parsed data as JSON text
     my $class = shift;
-    my $argv0 = shift // return undef;
-
-    die ' ***error: wrong number of arguments' if scalar @_ % 2;
+    my $argv0 = shift // return undef; die ' ***error: wrong number of arguments' if scalar @_ % 2;
     my $argv1 = { @_ };
     my $nyaan = __PACKAGE__->make($argv0, %$argv1) // [];
 

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -30,27 +30,14 @@ sub new {
     # @options argvs [String] data      Entire email message
     # @options argvs [Array]  load      User defined MTA module list
     # @options argvs [Array]  order     The order of MTA modules
-    # @options argvs [Array]  field     Email header names to be captured
     # @options argvs [Code]   hook      Reference to callback method
     # @return        [Sisimai::Message] Structured email data or Undef if each
     #                                   value of the arguments are missing
     my $class = shift;
     my $argvs = { @_ };
     my $email = $argvs->{'data'}  || return undef;
-    my $field = $argvs->{'field'} || [];
 
-    if( ref $field ne 'ARRAY' ) {
-        # Unsupported value in "field"
-        warn ' ***warning: "field" accepts an array reference only';
-        return undef;
-    }
-
-    my $methodargv = {
-        'data'  => $email,
-        'hook'  => $argvs->{'hook'} // undef,
-        'field' => $field,
-    };
-
+    my $methodargv = { 'data' => $email, 'hook' => $argvs->{'hook'} // undef };
     for my $e ('load', 'order') {
         # Order of MTA modules
         next unless exists $argvs->{ $e };
@@ -78,7 +65,6 @@ sub make {
     # @options argvs [String] data  Entire email message
     # @options argvs [Array]  load  User defined MTA module list
     # @options argvs [Array]  order The order of MTA modules
-    # @options argvs [Array]  field Email header names to be captured
     # @options argvs [Code]   hook  Reference to callback method
     # @return        [Hash]         Resolved data structure
     my $class = shift;
@@ -468,7 +454,6 @@ method like the following codes:
     my $message = Sisimai::Message->new(
         'data' => $mailtxt,
         'hook' => $cmethod,
-        'field' => ['X-Mailer', 'Precedence']
     );
     print $message->catch->{'x-mailer'};    # Apple Mail (2.1283)
     print $message->catch->{'queue-id'};    # 2DAEB222022E

--- a/t/001-sisimai.t
+++ b/t/001-sisimai.t
@@ -41,9 +41,6 @@ MAKE_TEST: {
     eval { $PackageName->dump('/dev/null', undef) };
     like $@, qr/error: wrong number of arguments/;
 
-    eval { $PackageName->make('/dev/null', 'field' => 22) };
-    like $@, qr/error: "field" accepts an array reference only/;
-
     for my $e ( 'mailbox', 'maildir', 'memory' ) {
         MAKE: {
             my $parseddata = undef;
@@ -116,10 +113,7 @@ MAKE_TEST: {
                 }
                 return $catch;
             };
-            $havecaught = $PackageName->make($SampleEmail->{ $e },
-                'hook'  => $callbackto,
-                'field' => ['X-Virus-Scanned'],
-            );
+            $havecaught = $PackageName->make($SampleEmail->{ $e }, 'hook' => $callbackto);
 
             for my $ee ( @$havecaught ) {
                 isa_ok $ee, 'Sisimai::Data';

--- a/t/040-message.t
+++ b/t/040-message.t
@@ -47,9 +47,6 @@ MAKE_TEST: {
     isa_ok $p->rfc822, 'HASH', '->rfc822';
     ok length $p->from, $p->from;
 
-    $p = Sisimai::Message->new('data' => $mailastext, 'field' => {});
-    is $p, undef;
-
     $p = Sisimai::Message->new(
             'data' => $mailastext, 
             'hook' => $callbackto,


### PR DESCRIPTION
- Each `field` parameter has been removed from the following methods because  Sisimai detect all the email header fields by `Sisimai::Message->makemap()` without having to specify field names at `field` parameter
    - `Sisimai->make`
    - `Sisimai::Message->new`
    - `Sisimai::Message->make`
