### PR TITLE
Issue 385 from address in multiple address

### DIFF
--- a/lib/Sisimai/ARF.pm
+++ b/lib/Sisimai/ARF.pm
@@ -154,11 +154,19 @@ sub make {
             } elsif( $e =~ /\AFrom:[ ]*(.+)\z/ ) {
                 # Microsoft ARF: original sender.
                 $commondata->{'from'} ||= Sisimai::Address->s3s4($1);
+                $previousfn = 'from';
 
             } elsif( $e =~ /\A[ \t]+/ ) {
                 # Continued line from the previous line
-                $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
-                next if length $e;
+                if( $previousfn eq 'from' ) {
+                    # Multiple lines at From: field
+                    $commondata->{'from'} .= $e;
+                    next;
+
+                } else {
+                    $rfc822part .= $e."\n" if exists $LongFields->{ $previousfn };
+                    next if length $e;
+                }
                 $rcptintext .= $e if $previousfn eq 'to';
 
             } else {

--- a/set-of-emails/maildir/bsd/arf-24.eml
+++ b/set-of-emails/maildir/bsd/arf-24.eml
@@ -1,0 +1,50 @@
+Delivered-To: abuse-report@example.com
+Received: by 192.0.2.25 with SMTP id fffffffff000000;
+    Thu, 29 Apr 2016 23:34:45 +0000 (UTC)
+X-Received: by 192.0.2.2 with SMTP id eeeeeeeee0000001.222.1500000000000;
+    Thu, 29 Apr 2016 23:34:45 +0000 (UTC)
+Return-Path: <neko@example.org>
+Received: from CAT000-NEKO2.example.com (cat000-neko2.example.com. [203.0.113.25])
+    by mx.example.com with ESMTPS id fffffffff11111.222.2016.04.29.23.34.45
+    for <abuse-report@example.com>
+    (version=TLSv1.2 cipher=ECDHE-RSA-AES128-SHA bits=128/128);
+    Thu, 29 Apr 2016 23:34:45 +0000 (UTC)
+Received: from CAT000-NEKO-022.r.example.org ([198.51.100.1]) by CAT004-R.example.com
+    with Microsoft SMTPSVC(7.5.7601.22751); Thu, 29 Apr 2016 23:34:45 +0000
+Date: Thu, 29 Apr 2016 23:34:45 +0000
+From: staff@hotmail.com
+Subject:  complaint about message from 192.0.2.222
+To: abuse-report@example.com
+MIME-Version: 1.0 
+Content-Type: multipart/mixed; boundary="F0000EEE2-0000-2111-AAB0-000000000000"
+Message-ID: <CAT0-NNE-000000000000000022@CAT0-RRR.example.org>
+X-OriginalArrivalTime: 29 Apr 2016 23:34:45.0000 (UTC) FILETIME=[FFFFFFFF:00000000]
+Return-Path: neko@example.org
+
+--F0000EEE2-0000-2111-AAB0-000000000000
+Content-Type: message/rfc822
+Content-Disposition: inline
+
+X-HmXmrOriginalRecipient: kijitora@example.com
+X-Reporter-IP: 192.0.2.22
+Authentication-Results: example.com; spf=pass (sender IP is 203.0.113.245; identity alignment result is pass and alignment mode is relaxed) smtp.mailfrom=sironeko@example.com; dkim=pass (identity alignment result is pass and alignment mode is relaxed) header.d=example.com; x-hmca=pass header.id=sironeko@example.com
+X-SID-PRA: sironeko@example.com
+X-AUTH-Result: PASS
+X-SID-Result: PASS
+Received: from smtp.example.com ([203.0.113.245]) by R7038-AA.example.com over TLS
+    secured channel with Microsoft SMTPSVC(7.5.7601.23008);
+    Thu, 29 Apr 2016 23:34:45 +0000
+Date: Thu, 29 Apr 2016 23:34:45 +0200
+To: kijitora@example.com
+From: name-part-looks-like-an-email-address@kyoto-japan
+    <sironeko@example.com>
+Subject: Nyaan
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+Content-Type: text/plain; charset="utf-8"
+Message-ID: <0000000000fffffffff0000000000000@example.com>
+X-OriginalArrivalTime: 29 Apr 2016 23:34:45.0000 (UTC) FILETIME=[00000000:FFFFFFFF]
+
+Nyaan
+
+--F0000EEE2-0000-2111-AAB0-000000000000--

--- a/t/600-lhost-code
+++ b/t/600-lhost-code
@@ -295,7 +295,7 @@ my $moduletest = sub {
                 }
 
                 for my $rr ( qw|addresser recipient| ) {
-                    $re = qr/\A.+[@][0-9A-Za-z-.]+[.][A-Za-z]+?\z/;
+                    $re = qr/\A.+[@][0-9A-Za-z.-]+[.][A-Za-z]+?\z/;
                     if( length $pr->$rr->alias ) {
                         $pp = 'alias'; like $pr->$rr->$pp, $re, sprintf(" [%s] %s->%s->%s = %s", $lb, $E, $rr, $pp, $pr->$rr->$pp);
                     }

--- a/t/600-lhost-code
+++ b/t/600-lhost-code
@@ -295,7 +295,7 @@ my $moduletest = sub {
                 }
 
                 for my $rr ( qw|addresser recipient| ) {
-                    $re = qr/[@]/;
+                    $re = qr/\A.+[@][0-9A-Za-z-.]+[.][A-Za-z]+?\z/;
                     if( length $pr->$rr->alias ) {
                         $pp = 'alias'; like $pr->$rr->$pp, $re, sprintf(" [%s] %s->%s->%s = %s", $lb, $E, $rr, $pp, $pr->$rr->$pp);
                     }

--- a/t/699-arf.t
+++ b/t/699-arf.t
@@ -21,6 +21,7 @@ my $isexpected = [
     { 'n' => '21', 's' => qr/\A\z/, 'r' => qr/feedback/, 'f' => qr/abuse/,        'b' => qr/\A-1\z/ },
     { 'n' => '22', 's' => qr/\A\z/, 'r' => qr/feedback/, 'f' => qr/abuse/,        'b' => qr/\A-1\z/ },
     { 'n' => '23', 's' => qr/\A\z/, 'r' => qr/feedback/, 'f' => qr/abuse/,        'b' => qr/\A-1\z/ },
+    { 'n' => '24', 's' => qr/\A\z/, 'r' => qr/feedback/, 'f' => qr/abuse/,        'b' => qr/\A-1\z/ },
 ];
 
 $enginetest->($enginename, $isexpected);


### PR DESCRIPTION
- #385 
- Failed to get an email address when multiple lines are in `From:` field at the original message part like the following, and a name part of the value of `From:` field is like an email address.

```
From: name-part-looks-like-an-email-address@kyoto-japan
    <sironeko@example.com>
```

