### PR TITLE
Remove old parameters at the callback

### DIFF
--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -271,11 +271,7 @@ sub parse {
 
     if( ref $hookmethod eq 'CODE' ) {
         # Call hook method
-        my $p = {
-            'datasrc' => 'email',
-            'headers' => $mailheader,
-            'message' => $$bodystring,
-        };
+        my $p = { 'headers' => $mailheader, 'message' => $$bodystring };
         eval { $havecaught = $hookmethod->($p) };
         warn sprintf(" ***warning: Something is wrong in hook method:%s", $@) if $@;
     }

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -275,7 +275,6 @@ sub parse {
             'datasrc' => 'email',
             'headers' => $mailheader,
             'message' => $$bodystring,
-            'bounces' => undef,
         };
         eval { $havecaught = $hookmethod->($p) };
         warn sprintf(" ***warning: Something is wrong in hook method:%s", $@) if $@;

--- a/t/001-sisimai.t
+++ b/t/001-sisimai.t
@@ -99,18 +99,15 @@ MAKE_TEST: {
             my $callbackto = sub {
                 my $argvs = shift;
                 my $catch = { 
-                    'type' => $argvs->{'datasrc'},
                     'x-mailer' => '',
                     'return-path' => '',
                     'x-virus-scanned' => '',
                 };
 
-                if( $argvs->{'datasrc'} eq 'email' ) {
-                    $catch->{'from'} = $argvs->{'headers'}->{'from'} || '';
-                    $catch->{'x-virus-scanned'} = $argvs->{'headers'}->{'x-virus-scanned'} || '';
-                    $catch->{'x-mailer'}    = $1 if $argvs->{'message'} =~ m/^X-Mailer:\s*(.*)$/m;
-                    $catch->{'return-path'} = $1 if $argvs->{'message'} =~ m/^Return-Path:\s*(.+)$/m;
-                }
+                $catch->{'from'} = $argvs->{'headers'}->{'from'} || '';
+                $catch->{'x-virus-scanned'} = $argvs->{'headers'}->{'x-virus-scanned'} || '';
+                $catch->{'x-mailer'}    = $1 if $argvs->{'message'} =~ m/^X-Mailer:\s*(.*)$/m;
+                $catch->{'return-path'} = $1 if $argvs->{'message'} =~ m/^Return-Path:\s*(.+)$/m;
                 return $catch;
             };
             $havecaught = $PackageName->make($SampleEmail->{ $e }, 'hook' => $callbackto);
@@ -119,7 +116,6 @@ MAKE_TEST: {
                 isa_ok $ee, 'Sisimai::Data';
                 isa_ok $ee->catch, 'HASH';
 
-                is $ee->catch->{'type'}, 'email';
                 ok defined $ee->catch->{'x-mailer'};
                 if( length $ee->catch->{'x-mailer'} ) {
                     like $ee->catch->{'x-mailer'}, qr/[A-Z]/;

--- a/t/040-message.t
+++ b/t/040-message.t
@@ -21,7 +21,6 @@ MAKE_TEST: {
     my $callbackto = sub {
         my $argvs = shift;
         my $catch = { 
-            'type' => $argvs->{'datasrc'},
             'x-mailer' => '',
             'return-path' => '',
         };
@@ -87,7 +86,6 @@ MAKE_TEST: {
     }
 
     isa_ok $p->catch, 'HASH';
-    is $p->catch->{'type'}, 'email';
     ok defined $p->catch->{'x-mailer'};
     ok defined $p->catch->{'return-path'};
     ok defined $p->catch->{'from'};

--- a/t/500-data.t
+++ b/t/500-data.t
@@ -30,7 +30,6 @@ MAKE_TEST: {
             'x-mailer' => '',
             'return-path' => '',
         };
-        $catch->{'type'} = $argvs->{'datasrc'};
         $catch->{'from'} = $argvs->{'headers'}->{'from'} || '';
         $catch->{'x-mailer'}    = $1 if $argvs->{'message'} =~ m/^X-Mailer:\s*(.*)$/m;
         $catch->{'return-path'} = $1 if $argvs->{'message'} =~ m/^Return-Path:\s*(.+)$/m;
@@ -92,7 +91,6 @@ MAKE_TEST: {
             is $e->origin, $file, 'origin = '.$e->origin;
 
             isa_ok $e->catch, 'HASH';
-            is $e->catch->{'type'}, 'email';
             ok length $e->catch->{'x-mailer'};
             like $e->catch->{'x-mailer'}, qr/Apple/;
             ok length $e->catch->{'return-path'};


### PR DESCRIPTION
Remove the following parameters at the callback feature:
- `datasrc`: Beginning from v4.25.5, input data source at the callback feature is only `email` 
- `bounces`: JSON format as an input data source is no longer available at v4.25.5 or later