### PR TITLE
Make "vacation" optional

### DIFF
--- a/README-JA.md
+++ b/README-JA.md
@@ -123,6 +123,11 @@ my $v = Sisimai->rise(\$r);
 # method like the following:
 my $v = Sisimai->rise('/path/to/mbox', 'delivered' => 1);
 
+# Beginning with v5.0.0, sisimai does not return the reulst which "reason" is "vaction" by default.
+# If you want to get bounce records which reason is "vacation", set "vacation" option to rise()
+# method like the following:
+my $v = Sisimai->rise('/path/to/mbox', 'vacation' => 1);
+
 if( defined $v ) {
     for my $e ( @$v ) {
         print ref $e;                   # Sisimai::Data

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ my $v = Sisimai->rise(\$r);
 # method like the following:
 my $v = Sisimai->rise('/path/to/mbox', 'delivered' => 1);
 
+# Beginning with v5.0.0, sisimai does not return the reulst which "reason" is "vaction" by default.
+# If you want to get bounce records which reason is "vacation", set "vacation" option to rise()
+# method like the following:
+my $v = Sisimai->rise('/path/to/mbox', 'vacation' => 1);
+
 if( defined $v ) {
     for my $e ( @$v ) {
         print ref $e;                   # Sisimai::Data

--- a/lib/Sisimai.pm
+++ b/lib/Sisimai.pm
@@ -22,6 +22,7 @@ sub rise {
     # @param         [Handle]  argv0      or STDIN
     # @param         [Hash]    argv1      Parser options
     # @options argv1 [Integer] delivered  1 = Including "delivered" reason
+    # @options argv1 [Integer] vacation   1 = Including "vacation" reason
     # @options argv1 [Array]   c___       Code references to a callback method for the message and each file
     # @return        [Array]              Parsed objects
     # @return        [undef]              undef if the argument was wrong or an empty array
@@ -40,7 +41,10 @@ sub rise {
     while( my $r = $mail->data->read ) {
         # Read and parse each email file
         my $path = $mail->data->path;
-        my $args = { 'data' => $r, 'hook' => $c___->[0], 'origin' => $path, 'delivered' => $argv1->{'delivered'} };
+        my $args = {
+            'data' => $r, 'hook' => $c___->[0], 'origin' => $path,
+            'delivered' => $argv1->{'delivered'}, 'vaction' => $argv1->{'vacation'}
+        };
         my $fact = Sisimai::Fact->rise($args) || [];
 
         if( $c___->[1] ) {
@@ -63,6 +67,7 @@ sub dump {
     # @param         [Handle]  argv0      or STDIN
     # @param         [Hash]    argv1      Parser options
     # @options argv1 [Integer] delivered  1 = Including "delivered" reason
+    # @options argv1 [Integer] vacation   1 = Including "vacation" reason
     # @options argv1 [Code]    hook       Code reference to a callback method
     # @return        [String]             Parsed data as JSON text
     my $class = shift;
@@ -198,10 +203,16 @@ C<make> method provides feature for getting parsed data from bounced email messa
         printf "%s\n", $json->encode($v);
     }
 
-If you want to get bounce records which reason is "delivered", set "delivered" option to make()
+If you want to get bounce records which reason is "delivered" or "vacation", set "delivered" or 
+"vacation" option to make() method like the following:
+
+    my $v = Sisimai->make('/path/to/mbox', 'delivered' => 1, 'vacation' => 1);
+
+Beginning with v5.0.0, sisimai does not return the reulst which "reason" is "vaction" by default.
+If you want to get bounce records which reason is "vacation", set "vacation" option to rise()
 method like the following:
 
-    my $v = Sisimai->make('/path/to/mbox', 'delivered' => 1);
+    my $v = Sisimai->rise('/path/to/mbox', 'vacation' => 1);
 
 =head2 C<B<dump(I<'/path/to/mbox'>)>>
 

--- a/lib/Sisimai/Fact.pm
+++ b/lib/Sisimai/Fact.pm
@@ -45,6 +45,7 @@ sub rise {
     # @param         [Hash]   argvs
     # @options argvs [String]  data         Entire email message
     # @options argvs [Integer] delivered    Include the result which has "delivered" reason
+    # @options argvs [Integer] vcacation    Include the result which has "vacation" reason
     # @options argvs [Code]    hook         Code reference to callback method
     # @options argvs [Array]   load         User defined MTA module list
     # @options argvs [Array]   order        The order of MTA modules
@@ -95,6 +96,10 @@ sub rise {
         unless( $argvs->{'delivered'} ) {
             # Skip if the value of "deliverystatus" begins with "2." such as 2.1.5
             next RISEOF if index($p->{'deliverystatus'}, '2.') == 0;
+        }
+        unless( $argvs->{'vacation'} ) {
+            # Skip if the value of "reason" is "vacation"
+            next RISEOF if $p->{'reason'} eq 'vacation';
         }
 
         EMAILADDRESS: {

--- a/t/600-lhost-code
+++ b/t/600-lhost-code
@@ -98,7 +98,7 @@ my $moduletest = sub {
 
         READ_EACH_EMAIL: while( my $r = $mailobject->data->read ) {
             # Read messages in each email
-            my $methodargs = { 'data' => $r, 'delivered' => 1, 'origin' => $cf };
+            my $methodargs = { 'data' => $r, 'delivered' => 1, 'vacation' => 1, 'origin' => $cf };
             my $listoffact = Sisimai::Fact->rise($methodargs);
 
             unless( $listoffact ) {


### PR DESCRIPTION
- #436
- Beginning with v5.0.0, sisimai does not return the result which reason is "vacation" by default
- If you want to get bounce records which reason is "vacation", set `"vacation" => 1` option to `SIsimai->rise` method