### PR TITLE
Use the Postfix dereference (Perl 5.26 or later) #446

### DIFF
--- a/lib/Sisimai.pm
+++ b/lib/Sisimai.pm
@@ -103,7 +103,7 @@ sub engine {
 
         if( $e eq 'Lhost' ) {
             # Sisimai::Lhost::*
-            for my $ee ( @{ $r->index } ) {
+            for my $ee ( $r->index->@* ) {
                 # Load and get the value of "description" from each module
                 my $rr = 'Sisimai::'.$e.'::'.$ee;
                 ($loads = $rr) =~ s|::|/|g;
@@ -126,7 +126,7 @@ sub reason {
 
     # These reasons are not included in the results of Sisimai::Reason->index
     require Sisimai::Reason;
-    my @names = (@{ Sisimai::Reason->index }, qw|Delivered Feedback Undefined Vacation|);
+    my @names = ( Sisimai::Reason->index->@*, qw|Delivered Feedback Undefined Vacation|);
 
     for my $e ( @names ) {
         # Call ->description() method of Sisimai::Reason::*
@@ -390,7 +390,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Address.pm
+++ b/lib/Sisimai/Address.pm
@@ -607,7 +607,7 @@ C<name()> returns a display name
 C<name()> returns a comment
 
     my $e = '"Neko, Nyaan" <neko(nyaan)@example.org>';
-    my $v = Sisimai::Address->new(shift @{ Sisimai::Address->find($e) });
+    my $v = Sisimai::Address->new(shift Sisimai::Address->find($e)->@*);
     print $v->address;  # neko@example.org
     print $v->comment;  # nyaan
 
@@ -617,7 +617,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/DateTime.pm
+++ b/lib/Sisimai/DateTime.pm
@@ -212,7 +212,7 @@ sub monthname {
     my $argv1 = shift // 0;
     my $value = $argv1 ? 'full' : 'abbr';
 
-    return @{ MonthName->{ $value } } if wantarray;
+    return MonthName->{ $value }->@* if wantarray;
     return MonthName->{ $value };
 }
 
@@ -227,7 +227,7 @@ sub dayofweek {
     my $argv1 = shift // 0;
     my $value = $argv1 ? 'full' : 'abbr';
 
-    return @{ DayOfWeek->{ $value } } if wantarray;
+    return DayOfWeek->{ $value }->@* if wantarray;
     return DayOfWeek->{ $value };
 }
 
@@ -266,11 +266,11 @@ sub parse {
             $p =~ s/,\z//g if substr($p, -1, 1) eq ','; # "Thu," => "Thu"
             $p =  substr($p, 0, 3) if length $p > 3;
 
-            if( grep { $p eq $_ } @{ DayOfWeek->{'abbr'} } ) {
+            if( grep { $p eq $_ } DayOfWeek->{'abbr'}->@* ) {
                 # Day of week; Mon, Thu, Sun,...
                 $v->{'a'} = $p;
 
-            } elsif( grep { $p eq $_ } @{ MonthName->{'abbr'} } ) {
+            } elsif( grep { $p eq $_ } MonthName->{'abbr'}->@* ) {
                 # Month name abbr.; Apr, May, ...
                 $v->{'M'} = $p;
             }
@@ -521,7 +521,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Fact.pm
+++ b/lib/Sisimai/Fact.pm
@@ -104,7 +104,7 @@ sub rise {
 
         EMAILADDRESS: {
             # Detect email address from message/rfc822 part
-            for my $f ( @{ $rfc822head->{'addresser'} } ) {
+            for my $f ( $rfc822head->{'addresser'}->@* ) {
                 # Check each header in message/rfc822 part
                 my $g = lc $f;
                 next unless exists $rfc822data->{ $g };
@@ -132,7 +132,7 @@ sub rise {
             my @datevalues; push @datevalues, $e->{'date'} if $e->{'date'};
 
             # Date information did not exist in message/delivery-status part,...
-            for my $f ( @{ $rfc822head->{'date'} } ) {
+            for my $f ( $rfc822head->{'date'}->@* ) {
                 # Get the value of Date header or other date related header.
                 next unless $rfc822data->{ $f };
                 push @datevalues, $rfc822data->{ $f };
@@ -167,8 +167,8 @@ sub rise {
             my $recvheader = $mesg1->{'header'}->{'received'} || [];
             if( scalar @$recvheader ) {
                 # Get localhost and remote host name from Received header.
-                $e->{'lhost'} ||= shift @{ Sisimai::RFC5322->received($recvheader->[0]) };
-                $e->{'rhost'} ||= pop   @{ Sisimai::RFC5322->received($recvheader->[-1]) };
+                $e->{'lhost'} ||= shift Sisimai::RFC5322->received($recvheader->[0])->@*;
+                $e->{'rhost'} ||= pop   Sisimai::RFC5322->received($recvheader->[-1])->@*;
             }
 
             for my $v ('rhost', 'lhost') {
@@ -689,7 +689,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Amavis.pm
+++ b/lib/Sisimai/Lhost/Amavis.pm
@@ -150,7 +150,7 @@ sub inquire {
         my $q = lc $e->{'diagnosis'};
         DETECT_REASON: for my $p ( keys %$messagesof ) {
             # Try to detect an error reason
-            for my $r ( @{ $messagesof->{ $p } } ) {
+            for my $r ( $messagesof->{ $p }->@* ) {
                 # Try to find an error message including lower-cased string defined in $messagesof
                 next unless index($q, $r) > -1;
                 $e->{'reason'} = $p;
@@ -198,7 +198,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2019-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2019-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/AmazonSES.pm
+++ b/lib/Sisimai/Lhost/AmazonSES.pm
@@ -191,7 +191,7 @@ sub inquire {
         if( exists $p->{'mail'}->{'headers'} ) {
             # "headersTruncated":false,
             # "headers":[ { ...
-            for my $e ( @{ $p->{'mail'}->{'headers'} } ) {
+            for my $e ( $p->{'mail'}->{'headers'}->@* ) {
                 # 'headers' => [ { 'name' => 'From', 'value' => 'neko@nyaan.jp' }, ... ],
                 next unless $e->{'name'} =~ /\A(?:From|To|Subject|Message-ID|Date)\z/;
                 $rfc822head->{ lc $e->{'name'} } = $e->{'value'};
@@ -306,7 +306,7 @@ sub inquire {
 
             SESSION: for my $r ( keys %$messagesof ) {
                 # Verify each regular expression of session errors
-                next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                 $e->{'reason'} = $r;
                 last;
             }
@@ -356,7 +356,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Aol.pm
+++ b/lib/Sisimai/Lhost/Aol.pm
@@ -114,7 +114,7 @@ sub inquire {
         $e->{'diagnosis'} =  Sisimai::String->sweep($e->{'diagnosis'});
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -159,7 +159,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/ApacheJames.pm
+++ b/lib/Sisimai/Lhost/ApacheJames.pm
@@ -22,7 +22,7 @@ sub inquire {
     # 'message-id' => qr/\d+[.]JavaMail[.].+[@]/,
     $match ||= 1 if $mhead->{'subject'} eq '[BOUNCE]';
     $match ||= 1 if defined $mhead->{'message-id'} && rindex($mhead->{'message-id'}, '.JavaMail.') > -1;
-    $match ||= 1 if grep { rindex($_, 'JAMES SMTP Server') > -1 } @{ $mhead->{'received'} };
+    $match ||= 1 if grep { rindex($_, 'JAMES SMTP Server') > -1 } $mhead->{'received'}->@*;
     return undef unless $match;
 
     state $indicators = __PACKAGE__->INDICATORS;
@@ -155,7 +155,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Bigfoot.pm
+++ b/lib/Sisimai/Lhost/Bigfoot.pm
@@ -19,7 +19,7 @@ sub inquire {
 
     # 'subject'  => qr/\AReturned mail: /,
     $match ||= 1 if rindex($mhead->{'from'}, '@bigfoot.com>') > -1;
-    $match ||= 1 if grep { rindex($_, '.bigfoot.com ') > -1 } @{ $mhead->{'received'} };
+    $match ||= 1 if grep { rindex($_, '.bigfoot.com ') > -1 } $mhead->{'received'}->@*;
     return undef unless $match;
 
     state $indicators = __PACKAGE__->INDICATORS;
@@ -161,7 +161,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Biglobe.pm
+++ b/lib/Sisimai/Lhost/Biglobe.pm
@@ -89,7 +89,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -134,7 +134,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Courier.pm
+++ b/lib/Sisimai/Lhost/Courier.pm
@@ -148,7 +148,7 @@ sub inquire {
 
         for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -194,7 +194,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Domino.pm
+++ b/lib/Sisimai/Lhost/Domino.pm
@@ -5,7 +5,7 @@ use strict;
 use warnings;
 use Sisimai::String;
 use Encode;
-use Encode::Guess; Encode::Guess->add_suspects(@{ Sisimai::String->encodenames });
+use Encode::Guess; Encode::Guess->add_suspects(Sisimai::String->encodenames->@*);
 
 sub description { 'IBM Domino Server' }
 sub inquire {
@@ -145,7 +145,7 @@ sub inquire {
 
         for my $r ( keys %$messagesof ) {
             # Check each regular expression of Domino error messages
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'}   = $r;
             $e->{'status'} ||= Sisimai::SMTP::Status->code($r, 0) || '';
             last;
@@ -195,7 +195,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/EZweb.pm
+++ b/lib/Sisimai/Lhost/EZweb.pm
@@ -26,8 +26,8 @@ sub inquire {
     $match++ if rindex($mhead->{'from'}, 'Postmaster@ezweb.ne.jp') > -1;
     $match++ if rindex($mhead->{'from'}, 'Postmaster@au.com') > -1;
     $match++ if $mhead->{'subject'} eq 'Mail System Error - Returned Mail';
-    $match++ if grep { rindex($_, 'ezweb.ne.jp (EZweb Mail) with') > -1 } @{ $mhead->{'received'} };
-    $match++ if grep { rindex($_, '.au.com (') > -1 } @{ $mhead->{'received'} };
+    $match++ if grep { rindex($_, 'ezweb.ne.jp (EZweb Mail) with') > -1 } $mhead->{'received'}->@*;
+    $match++ if grep { rindex($_, '.au.com (') > -1 } $mhead->{'received'}->@*;
     if( defined $mhead->{'message-id'} ) {
         $match++ if substr($mhead->{'message-id'}, -13, 13) eq '.ezweb.ne.jp>';
         $match++ if substr($mhead->{'message-id'}, -8, 8) eq '.au.com>';
@@ -76,7 +76,7 @@ sub inquire {
         my $b0 = Sisimai::RFC2045->boundary($mhead->{'content-type'}, 1);
         $markingsof->{'boundary'} = qr/\A\Q$b0\E\z/ if $b0; # Convert to regular expression
     }
-    my @rxmessages; push @rxmessages, @{ $refailures->{ $_ } } for keys %$refailures;
+    my @rxmessages; push @rxmessages, $refailures->{ $_ }->@* for keys %$refailures;
 
     for my $e ( split("\n", $emailsteak->[0]) ) {
         # Read error messages and delivery status lines from the head of the email to the previous
@@ -168,7 +168,7 @@ sub inquire {
                 # SMTP command is not RCPT
                 SESSION: for my $r ( keys %$refailures ) {
                     # Verify each regular expression of session errors
-                    PATTERN: for my $rr ( @{ $refailures->{ $r } } ) {
+                    PATTERN: for my $rr ( $refailures->{ $r }->@* ) {
                         # Check each regular expression
                         next(PATTERN) unless $e->{'diagnosis'} =~ $rr;
                         $e->{'reason'} = $r;
@@ -220,7 +220,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/EinsUndEins.pm
+++ b/lib/Sisimai/Lhost/EinsUndEins.pm
@@ -103,7 +103,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -148,7 +148,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Exchange2003.pm
+++ b/lib/Sisimai/Lhost/Exchange2003.pm
@@ -40,8 +40,8 @@ sub inquire {
             last if $match;
         }
 
-        last unless scalar @{ $mhead->{'received'} };
-        for my $e ( @{ $mhead->{'received'} } ) {
+        last unless scalar $mhead->{'received'}->@*;
+        for my $e ( $mhead->{'received'}->@* ) {
             # Received: by ***.**.** with Internet Mail Service (5.5.2657.72)
             next unless rindex($e, ' with Internet Mail Service (') > -1;
             $match = 1;
@@ -196,7 +196,7 @@ sub inquire {
 
             for my $r ( keys %$errorcodes ) {
                 # Find captured code from the error code table
-                next unless grep { $capturedcode eq $_ } @{ $errorcodes->{ $r } };
+                next unless grep { $capturedcode eq $_ } $errorcodes->{ $r }->@*;
                 $e->{'reason'} = $r;
                 $e->{'status'} = Sisimai::SMTP::Status->code($r) || '';
                 last;
@@ -260,7 +260,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Exim.pm
+++ b/lib/Sisimai/Lhost/Exim.pm
@@ -318,7 +318,7 @@ sub inquire {
     }
     return undef unless $recipients;
 
-    if( scalar @{ $mhead->{'received'} } ) {
+    if( scalar $mhead->{'received'}->@* ) {
         # Get the name of local MTA
         # Received: from marutamachi.example.org (c192128.example.net [192.0.2.128])
         $localhost0 = $1 if $mhead->{'received'}->[-1] =~ /from[ \t]([^ ]+) /;
@@ -381,10 +381,10 @@ sub inquire {
             # host neko.example.jp [192.0.2.222]: 550 5.1.1 <kijitora@example.jp>... User Unknown
             $e->{'rhost'} = $1 if $e->{'diagnosis'} =~ /host[ \t]+([^ \t]+)[ \t]\[.+\]:[ \t]/;
 
-            if( ! $e->{'rhost'} && scalar @{ $mhead->{'received'} } ) {
+            if( ! $e->{'rhost'} && scalar $mhead->{'received'}->@* ) {
                 # Get localhost and remote host name from Received header.
                 my $r0 = $mhead->{'received'};
-                $e->{'rhost'} = pop @{ Sisimai::RFC5322->received($r0->[-1]) };
+                $e->{'rhost'} = pop Sisimai::RFC5322->received($r0->[-1])->@*;
             }
         }
 
@@ -410,7 +410,7 @@ sub inquire {
                 # Verify each regular expression of session errors
                 SESSION: for my $r ( keys %$messagesof ) {
                     # Check each regular expression
-                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                     $e->{'reason'} = $r;
                     last;
                 }
@@ -521,7 +521,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Facebook.pm
+++ b/lib/Sisimai/Lhost/Facebook.pm
@@ -163,7 +163,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$errorcodes ) {
             # Verify each regular expression of session errors
-            PATTERN: for my $rr ( @{ $errorcodes->{ $r } } ) {
+            PATTERN: for my $rr ( $errorcodes->{ $r }->@* ) {
                 # Check each regular expression
                 next(PATTERN) unless $fbresponse eq $rr;
                 $e->{'reason'} = $r;
@@ -226,7 +226,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/GMX.pm
+++ b/lib/Sisimai/Lhost/GMX.pm
@@ -105,7 +105,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -150,7 +150,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/GSuite.pm
+++ b/lib/Sisimai/Lhost/GSuite.pm
@@ -186,7 +186,7 @@ sub inquire {
 
         for my $q ( keys %$messagesof ) {
             # Guess an reason of the bounce
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $q } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $q }->@*;
             $e->{'reason'} = $q;
             last;
         }
@@ -231,7 +231,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Gmail.pm
+++ b/lib/Sisimai/Lhost/Gmail.pm
@@ -239,7 +239,7 @@ sub inquire {
             # No state code
             SESSION: for my $r ( keys %$messagesof ) {
                 # Verify each regular expression of session errors
-                next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                 $e->{'reason'} = $r;
                 last;
             }
@@ -291,7 +291,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/KDDI.pm
+++ b/lib/Sisimai/Lhost/KDDI.pm
@@ -20,8 +20,8 @@ sub inquire {
     # 'message-id' => qr/[@].+[.]ezweb[.]ne[.]jp[>]\z/,
     $match ||= 1 if $mhead->{'from'} =~ /no-reply[@].+[.]dion[.]ne[.]jp/;
     $match ||= 1 if $mhead->{'reply-to'} && $mhead->{'reply-to'} eq 'no-reply@app.auone-net.jp';
-    $match ||= 1 if grep { rindex($_, 'ezweb.ne.jp (') > -1 } @{ $mhead->{'received'} };
-    $match ||= 1 if grep { rindex($_, '.au.com (') > -1 } @{ $mhead->{'received'} };
+    $match ||= 1 if grep { rindex($_, 'ezweb.ne.jp (') > -1 } $mhead->{'received'}->@*;
+    $match ||= 1 if grep { rindex($_, '.au.com (') > -1 } $mhead->{'received'}->@*;
     return undef unless $match;
 
     state $indicators = __PACKAGE__->INDICATORS;
@@ -99,7 +99,7 @@ sub inquire {
                 # SMTP command is not RCPT
                 SESSION: for my $r ( keys %$messagesof ) {
                     # Verify each regular expression of session errors
-                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                     $e->{'reason'} = $r;
                     last;
                 }
@@ -145,7 +145,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MXLogic.pm
+++ b/lib/Sisimai/Lhost/MXLogic.pm
@@ -129,7 +129,7 @@ sub inquire {
     }
     return undef unless $recipients;
 
-    if( scalar @{ $mhead->{'received'} } ) {
+    if( scalar $mhead->{'received'}->@* ) {
         # Get the name of local MTA
         # Received: from marutamachi.example.org (c192128.example.net [192.0.2.128])
         $localhost0 = $1 if $mhead->{'received'}->[-1] =~ /from[ \t]([^ ]+) /;
@@ -147,9 +147,9 @@ sub inquire {
             $e->{'rhost'} = $1 if $e->{'diagnosis'} =~ /host[ \t]+([^ \t]+)[ \t]\[.+\]:[ \t]/;
 
             unless( $e->{'rhost'} ) {
-                if( scalar @{ $mhead->{'received'} } ) {
+                if( scalar $mhead->{'received'}->@* ) {
                     # Get localhost and remote host name from Received header.
-                    $e->{'rhost'} = pop @{ Sisimai::RFC5322->received($mhead->{'received'}->[-1]) };
+                    $e->{'rhost'} = pop Sisimai::RFC5322->received($mhead->{'received'}->[-1])->@*;
                 }
             }
         }
@@ -176,7 +176,7 @@ sub inquire {
                 # Verify each regular expression of session errors
                 SESSION: for my $r ( keys %$messagesof ) {
                     # Check each regular expression
-                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                     $e->{'reason'} = $r;
                     last;
                 }
@@ -229,7 +229,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MailFoundry.pm
+++ b/lib/Sisimai/Lhost/MailFoundry.pm
@@ -17,7 +17,7 @@ sub inquire {
     my $mbody = shift // return undef;
 
     return undef unless $mhead->{'subject'} eq 'Message delivery has failed';
-    return undef unless grep { rindex($_, '(MAILFOUNDRY) id') > -1 } @{ $mhead->{'received'} };
+    return undef unless grep { rindex($_, '(MAILFOUNDRY) id') > -1 } $mhead->{'received'}->@*;
 
     state $indicators = __PACKAGE__->INDICATORS;
     state $rebackbone = qr|^Content-Type:[ ]message/rfc822|m;
@@ -122,7 +122,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MailRu.pm
+++ b/lib/Sisimai/Lhost/MailRu.pm
@@ -141,7 +141,7 @@ sub inquire {
     }
     return undef unless $recipients;
 
-    if( scalar @{ $mhead->{'received'} } ) {
+    if( scalar $mhead->{'received'}->@* ) {
         # Get the name of local MTA
         # Received: from marutamachi.example.org (c192128.example.net [192.0.2.128])
         $localhost0 = $1 if $mhead->{'received'}->[-1] =~ /from[ \t]([^ ]+) /;
@@ -166,10 +166,10 @@ sub inquire {
             $e->{'rhost'} = $1 if $e->{'diagnosis'} =~ /host[ \t]+([^ \t]+)[ \t]\[.+\]:[ \t]/;
 
             unless( $e->{'rhost'} ) {
-                if( scalar @{ $mhead->{'received'} } ) {
+                if( scalar $mhead->{'received'}->@* ) {
                     # Get localhost and remote host name from Received header.
                     my $r0 = $mhead->{'received'};
-                    $e->{'rhost'} = pop @{ Sisimai::RFC5322->received($r0->[-1]) };
+                    $e->{'rhost'} = pop Sisimai::RFC5322->received($r0->[-1])->@*;
                 }
             }
         }
@@ -197,7 +197,7 @@ sub inquire {
                 } else {
                     SESSION: for my $r ( keys %$messagesof ) {
                         # Verify each regular expression of session errors
-                        next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                        next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                         $e->{'reason'} = $r;
                         last;
                     }
@@ -247,7 +247,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MessagingServer.pm
+++ b/lib/Sisimai/Lhost/MessagingServer.pm
@@ -141,7 +141,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -187,7 +187,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Notes.pm
+++ b/lib/Sisimai/Lhost/Notes.pm
@@ -107,7 +107,7 @@ sub inquire {
 
         for my $r ( keys %$messagesof ) {
             # Check each regular expression of Notes error messages
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             $e->{'status'} = Sisimai::SMTP::Status->code($r) || '';
             last;
@@ -153,7 +153,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Office365.pm
+++ b/lib/Sisimai/Lhost/Office365.pm
@@ -35,7 +35,7 @@ sub inquire {
     $match++ if $mhead->{'x-ms-exchange-crosstenant-originalarrivaltime'};
     $match++ if $mhead->{'x-ms-exchange-crosstenant-fromentityheader'};
     $match++ if $mhead->{'x-ms-exchange-transport-crosstenantheadersstamped'};
-    $match++ if grep { $_ =~ $tryto } @{ $mhead->{'received'} };
+    $match++ if grep { $_ =~ $tryto } $mhead->{'received'}->@*;
     if( defined $mhead->{'message-id'} ) {
         # Message-ID: <00000000-0000-0000-0000-000000000000@*.*.prod.outlook.com>
         $match++ if $mhead->{'message-id'} =~ $tryto;
@@ -275,7 +275,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/OpenSMTPD.pm
+++ b/lib/Sisimai/Lhost/OpenSMTPD.pm
@@ -18,7 +18,7 @@ sub inquire {
 
     return undef unless index($mhead->{'subject'}, 'Delivery status notification') > -1;
     return undef unless index($mhead->{'from'}, 'Mailer Daemon <') > -1;
-    return undef unless grep { rindex($_, ' (OpenSMTPD) with ') > -1 } @{ $mhead->{'received'} };
+    return undef unless grep { rindex($_, ' (OpenSMTPD) with ') > -1 } $mhead->{'received'}->@*;
 
     state $indicators = __PACKAGE__->INDICATORS;
     state $rebackbone = qr|^[ ]+Below is a copy of the original message:|m;
@@ -127,7 +127,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -172,7 +172,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Outlook.pm
+++ b/lib/Sisimai/Lhost/Outlook.pm
@@ -22,7 +22,7 @@ sub inquire {
     $match++ if index($mhead->{'subject'}, 'Delivery Status Notification') > -1;
     $match++ if $mhead->{'x-message-delivery'};
     $match++ if $mhead->{'x-message-info'};
-    $match++ if grep { rindex($_, '.hotmail.com') > -1 } @{ $mhead->{'received'} };
+    $match++ if grep { rindex($_, '.hotmail.com') > -1 } $mhead->{'received'}->@*;
     return undef if $match < 2;
 
     state $indicators = __PACKAGE__->INDICATORS;
@@ -123,7 +123,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -168,7 +168,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Postfix.pm
+++ b/lib/Sisimai/Lhost/Postfix.pm
@@ -101,7 +101,7 @@ sub inquire {
             next if int($p->{'reply'}) < 400;
 
             push @commandset, $e->{'command'};
-            $v->{'diagnosis'} ||= join(' ', @{ $p->{'text'} });
+            $v->{'diagnosis'} ||= join ' ', $p->{'text'}->@*;
             $v->{'replycode'} ||= $p->{'reply'};
             $v->{'status'}    ||= $p->{'status'};
         }

--- a/lib/Sisimai/Lhost/ReceivingSES.pm
+++ b/lib/Sisimai/Lhost/ReceivingSES.pm
@@ -118,7 +118,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -164,7 +164,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Verizon.pm
+++ b/lib/Sisimai/Lhost/Verizon.pm
@@ -20,7 +20,7 @@ sub inquire {
     while(1) {
         # Check the value of "From" header
         # 'subject' => qr/Undeliverable Message/,
-        last unless grep { rindex($_, '.vtext.com (') > -1 } @{ $mhead->{'received'} };
+        last unless grep { rindex($_, '.vtext.com (') > -1 } $mhead->{'received'}->@*;
         $match = 1 if $mhead->{'from'} eq 'post_master@vtext.com';
         $match = 0 if $mhead->{'from'} =~ /[<]?sysadmin[@].+[.]vzwpix[.]com[>]?\z/;
         last;
@@ -162,7 +162,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -207,7 +207,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X4.pm
+++ b/lib/Sisimai/Lhost/X4.pm
@@ -24,7 +24,7 @@ sub inquire {
     #         Subject: failure notice
     $match ||= 1 if index($mhead->{'subject'}, 'failure notice') == 0;
     $match ||= 1 if index($mhead->{'subject'}, 'Permanent Delivery Failure') == 0;
-    $match ||= 1 if grep { $_ =~ $tryto } @{ $mhead->{'received'} };
+    $match ||= 1 if grep { $_ =~ $tryto } $mhead->{'received'}->@*;
     return undef unless $match;
 
     state $indicators = __PACKAGE__->INDICATORS;
@@ -225,12 +225,12 @@ sub inquire {
                     # Verify each regular expression of session errors
                     if( $e->{'alterrors'} ) {
                         # Check the value of "alterrors"
-                        next unless grep { index($e->{'alterrors'}, $_) > -1 } @{ $messagesof->{ $r } };
+                        next unless grep { index($e->{'alterrors'}, $_) > -1 } $messagesof->{ $r }->@*;
                         $e->{'reason'} = $r;
                     }
                     last if $e->{'reason'};
 
-                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                     $e->{'reason'} = $r;
                     last;
                 }
@@ -238,7 +238,7 @@ sub inquire {
                 unless( $e->{'reason'} ) {
                     LDAP: for my $r ( keys %$failonldap ) {
                         # Verify each regular expression of LDAP errors
-                        next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $failonldap->{ $r } };
+                        next unless grep { index($e->{'diagnosis'}, $_) > -1 } $failonldap->{ $r }->@*;
                         $e->{'reason'} = $r;
                         last;
                     }
@@ -291,7 +291,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Zoho.pm
+++ b/lib/Sisimai/Lhost/Zoho.pm
@@ -100,7 +100,7 @@ sub inquire {
 
         SESSION: for my $r ( keys %$messagesof ) {
             # Verify each regular expression of session errors
-            next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+            next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
             $e->{'reason'} = $r;
             last;
         }
@@ -145,7 +145,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/mFILTER.pm
+++ b/lib/Sisimai/Lhost/mFILTER.pm
@@ -104,11 +104,11 @@ sub inquire {
         $e->{'diagnosis'} = Sisimai::String->sweep($e->{'diagnosis'});
 
         # Get localhost and remote host name from Received header.
-        next unless scalar @{ $mhead->{'received'} };
+        next unless scalar $mhead->{'received'}->@*;
         my $rheads = $mhead->{'received'};
         my $rhosts = Sisimai::RFC5322->received($rheads->[-1]);
 
-        $e->{'lhost'} ||= shift @{ Sisimai::RFC5322->received($rheads->[0]) };
+        $e->{'lhost'} ||= shift Sisimai::RFC5322->received($rheads->[0])->@*;
         for my $ee ( @$rhosts ) {
             # Avoid "... by m-FILTER"
             next unless rindex($ee, '.') > -1;
@@ -155,7 +155,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/qmail.pm
+++ b/lib/Sisimai/Lhost/qmail.pm
@@ -23,7 +23,7 @@ sub inquire {
     #   e.g.) Received: (qmail 12345 invoked for bounce); 29 Apr 2009 12:34:56 -0000
     #         Subject: failure notice
     $match ||= 1 if $mhead->{'subject'} eq 'failure notice';
-    $match ||= 1 if grep { $_ =~ $tryto } @{ $mhead->{'received'} };
+    $match ||= 1 if grep { $_ =~ $tryto } $mhead->{'received'}->@*;
     return undef unless $match;
 
     state $indicators = __PACKAGE__->INDICATORS;
@@ -206,12 +206,12 @@ sub inquire {
                     # Verify each regular expression of session errors
                     if( $e->{'alterrors'} ) {
                         # Check the value of "alterrors"
-                        next unless grep { index($e->{'alterrors'}, $_) > -1 } @{ $messagesof->{ $r } };
+                        next unless grep { index($e->{'alterrors'}, $_) > -1 } $messagesof->{ $r }->@*;
                         $e->{'reason'} = $r;
                     }
                     last if $e->{'reason'};
 
-                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $messagesof->{ $r } };
+                    next unless grep { index($e->{'diagnosis'}, $_) > -1 } $messagesof->{ $r }->@*;
                     $e->{'reason'} = $r;
                     last;
                 }
@@ -219,7 +219,7 @@ sub inquire {
                 unless( $e->{'reason'} ) {
                     LDAP: for my $r ( keys %$failonldap ) {
                         # Verify each regular expression of LDAP errors
-                        next unless grep { index($e->{'diagnosis'}, $_) > -1 } @{ $failonldap->{ $r } };
+                        next unless grep { index($e->{'diagnosis'}, $_) > -1 } $failonldap->{ $r }->@*;
                         $e->{'reason'} = $r;
                         last;
                     }
@@ -273,7 +273,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/MDA.pm
+++ b/lib/Sisimai/MDA.pm
@@ -119,11 +119,11 @@ sub inquire {
     return undef unless $agentname0;
     return undef unless scalar @linebuffer;
 
-    for my $e ( keys %{ $messagesof->{ $agentname0 } } ) {
+    for my $e ( keys $messagesof->{ $agentname0 }->%* ) {
         # Detect an error reason from message patterns of the MDA.
         for my $f ( @linebuffer ) {
             # Whether the error message include each message defined in $messagesof
-            next unless grep { index(lc($f), $_) > -1 } @{ $messagesof->{ $agentname0 }->{ $e } };
+            next unless grep { index(lc($f), $_) > -1 } $messagesof->{ $agentname0 }->{ $e }->@*;
             $reasonname = $e;
             $bouncemesg = $f;
             last;
@@ -181,7 +181,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Mail/Memory.pm
+++ b/lib/Sisimai/Mail/Memory.pm
@@ -32,8 +32,8 @@ sub new {
     if( (substr($$argv1, 0, 5) || '') eq 'From ') {
         # UNIX mbox
         $param->{'payload'} = [split(/^From /m, $$argv1)];
-        shift @{ $param->{'payload'} };
-        $_ = 'From '.$_ for @{ $param->{'payload'} };
+        shift $param->{'payload'}->@*;
+        $_ = 'From '.$_ for $param->{'payload'}->@*;
     } else {
         $param->{'payload'} = [$$argv1];
     }
@@ -44,10 +44,10 @@ sub read {
     # Memory reader, works as a iterator.
     # @return   [String] Contents of a bounce mail
     my $self = shift;
-    return undef unless scalar @{ $self->{'payload'} };
+    return undef unless scalar $self->{'payload'}->@*;
 
     $self->{'offset'} += 1;
-    return shift @{ $self->{'payload'} };
+    return shift $self->{'payload'}->@*;
 }
 
 1;
@@ -98,7 +98,7 @@ C<size()> returns a memory size of the mailbox or JSON string.
 
 C<payload()> returns an array reference to each email message or JSON string
 
-    print scalar @{ $mailobj->payload };   # 17
+    print scalar $mailobj->payload->@*; # 17
 
 =head2 C<B<offset()>>
 
@@ -123,7 +123,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2018-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -33,7 +33,7 @@ sub rise {
         # Order of MTA modules
         next unless exists $argvs->{ $e };
         next unless ref $argvs->{ $e } eq 'ARRAY';
-        next unless scalar @{ $argvs->{ $e } };
+        next unless scalar $argvs->{ $e }->@*;
         $param->{ $e } = $argvs->{ $e };
     }
     $ToBeLoaded = __PACKAGE__->load(%$param);
@@ -107,13 +107,13 @@ sub load {
         # The order of MTA modules specified by user
         next unless exists $argvs->{ $e };
         next unless ref $argvs->{ $e } eq 'ARRAY';
-        next unless scalar @{ $argvs->{ $e } };
+        next unless scalar $argvs->{ $e }->@*;
 
-        push @modulelist, @{ $argvs->{'order'} } if $e eq 'order';
+        push @modulelist, $argvs->{'order'}->@* if $e eq 'order';
         next unless $e eq 'load';
 
         # Load user defined MTA module
-        for my $v ( @{ $argvs->{'load'} } ) {
+        for my $v ( $argvs->{'load'}->@* ) {
             # Load user defined MTA module
             eval {
                 (my $modulepath = $v) =~ s|::|/|g;
@@ -338,7 +338,7 @@ sub parse {
 
     $parseddata->{'catch'} = $havecaught;
     $modulename =~ s/\A.+:://;
-    $_->{'agent'} ||= $modulename for @{ $parseddata->{'ds'} };
+    $_->{'agent'} ||= $modulename for $parseddata->{'ds'}->@*;
     return $parseddata;
 }
 
@@ -441,7 +441,7 @@ C<header()> returns the header part of the email.
 
 C<ds()> returns an array reference which include contents of delivery status.
 
-    for my $e ( @{ $message->ds } ) {
+    for my $e ( $message->ds->@* ) {
         print $e->{'status'};   # 5.1.1
         print $e->{'recipient'};# neko@example.jp
     }
@@ -464,7 +464,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Order.pm
+++ b/lib/Sisimai/Order.pm
@@ -123,7 +123,7 @@ sub default {
     # Make default order of MTA modules to be loaded
     # @return   [Array] Default order list of MTA modules
     # @since v4.13.1
-    return [map { 'Sisimai::Lhost::'.$_ } @{ Sisimai::Lhost->index() }];
+    return [map { 'Sisimai::Lhost::'.$_ } Sisimai::Lhost->index()->@*];
 }
 
 sub another {
@@ -224,14 +224,14 @@ JSON structure.
 C<default()> returns a default order of MTA modules as an array reference. The default order is
 defined at Sisimai::Lhost->index method.
 
-    print for @{ Sisimai::Order->default };
+    print for Sisimai::Order->default->@*;
 
 =head2 C<B<another()>>
 
 C<another()> returns another list of MTA modules as an array reference. Another list is defined at
 this class.
 
-    print for @{ Sisimai::Order->another };
+    print for Sisimai::Order->another->@*;
 
 =head1 AUTHOR
 
@@ -239,7 +239,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2017,2019-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2017,2019-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC1894.pm
+++ b/lib/Sisimai/RFC1894.pm
@@ -59,8 +59,8 @@ sub match {
             Diagnostic-Code Last-Attempt-Date X-Actual-Recipient|],
     ];
 
-    return 1 if grep { index($argv0, $_) == 0 } @{ $fieldnames->[0] };
-    return 2 if grep { index($argv0, $_) == 0 } @{ $fieldnames->[1] };
+    return 1 if grep { index($argv0, $_) == 0 } $fieldnames->[0]->@*;
+    return 2 if grep { index($argv0, $_) == 0 } $fieldnames->[1]->@*;
     return 0;
 }
 
@@ -193,7 +193,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2018-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC2045.pm
+++ b/lib/Sisimai/RFC2045.pm
@@ -318,17 +318,17 @@ sub makeflat {
             # Check the value of Content-Transfer-Encoding: header
             if( $ctencoding eq 'base64' ) {
                 # Content-Transfer-Encoding: base64
-                $bodystring = ${ __PACKAGE__->decodeB(\$bodyinside) };
+                $bodystring = __PACKAGE__->decodeB(\$bodyinside)->$*;
 
             } elsif( $ctencoding eq 'quoted-printable') {
                 # Content-Transfer-Encoding: quoted-printable
-                $bodystring = ${ __PACKAGE__->decodeQ(\$bodyinside) };
+                $bodystring = __PACKAGE__->decodeQ(\$bodyinside)->$*;
 
             } elsif( $ctencoding eq '7bit' ) {
                 # Content-Transfer-Encoding: 7bit
                 if( lc $e->[0] =~ $iso2022set ) {
                     # Content-Type: text/plain; charset=ISO-2022-JP
-                    $bodystring = ${ Sisimai::String->to_utf8(\$bodyinside, $1) };
+                    $bodystring = Sisimai::String->to_utf8(\$bodyinside, $1)->$*;
 
                 } else {
                     # No "charset" parameter in the value of Content-Type: header
@@ -340,7 +340,7 @@ sub makeflat {
             }
 
             # Try to delete HTML tags inside of text/html part whenever possible
-            $bodystring = ${ Sisimai::String->to_plain(\$bodystring) } if $istexthtml;
+            $bodystring = Sisimai::String->to_plain(\$bodystring)->$* if $istexthtml;
             next unless $bodystring;
             $bodystring =~ s|\r\n|\n|g if index($bodystring, "\r\n") > -1;    # Convert CRLF to LF
 
@@ -458,7 +458,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -14,7 +14,7 @@ use constant HEADERTABLE => {
 my $HEADERINDEX = {};
 BUILD_FLATTEN_RFC822HEADER_LIST: {
     # Convert $HEADER: hash reference to flatten hash reference for being called from Sisimai::Lhost::*
-    for my $v ( values %{ HEADERTABLE() } ) {
+    for my $v ( values HEADERTABLE()->%* ) {
         $HEADERINDEX->{ $_ } = 1 for @$v;
     }
 }

--- a/lib/Sisimai/Reason.pm
+++ b/lib/Sisimai/Reason.pm
@@ -66,7 +66,7 @@ sub get {
     my $reasontext = '';
     if( $argvs->{'diagnostictype'} eq 'SMTP' || $argvs->{'diagnostictype'} eq '' ) {
         # Diagnostic-Code: SMTP; ... or empty value
-        for my $e ( @{ $ClassOrder->[0] } ) {
+        for my $e ( $ClassOrder->[0]->@* ) {
             # Check the values of Diagnostic-Code: and Status: fields using true() method of each
             # child class in Sisimai::Reason
             my $p = 'Sisimai::Reason::'.$e;
@@ -115,7 +115,7 @@ sub anotherone {
         last unless $trytomatch;
 
         # Could not decide the reason by the value of Status:
-        for my $e ( @{ $ClassOrder->[1] } ) {
+        for my $e ( $ClassOrder->[1]->@* ) {
             # Trying to match with other patterns in Sisimai::Reason::* classes
             my $p = 'Sisimai::Reason::'.$e;
             require $ModulePath->{ $p };
@@ -175,7 +175,7 @@ sub match {
     my $diagnostic = lc $argv1;
 
     # Diagnostic-Code: SMTP; ... or empty value
-    for my $e ( @{ $ClassOrder->[2] } ) {
+    for my $e ( $ClassOrder->[2]->@* ) {
         # Check the values of Diagnostic-Code: and Status: fields using true() method of each child
         # class in Sisimai::Reason
         my $p = 'Sisimai::Reason::'.$e;
@@ -518,7 +518,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost.pm
+++ b/lib/Sisimai/Rhost.pm
@@ -25,7 +25,7 @@ sub match {
     my $host0 = lc($rhost) || return 0;
     my $match = 0;
 
-    for my $e ( keys %{ RhostClass() } ) {
+    for my $e ( keys RhostClass()->%* ) {
         # Try to match with each key of RhostClass
         next unless $host0 =~ $e;
         $match = 1;
@@ -46,7 +46,7 @@ sub get {
     my $remotehost = $proxy || lc $argvs->{'rhost'};
     my $rhostclass = '';
 
-    for my $e ( keys %{ RhostClass() } ) {
+    for my $e ( keys RhostClass()->%* ) {
         # Try to match with each key of RhostClass
         next unless $remotehost =~ $e;
         $rhostclass = __PACKAGE__.'::'.RhostClass->{ $e };
@@ -96,7 +96,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2020 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020,2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Cox.pm
+++ b/lib/Sisimai/Rhost/Cox.pm
@@ -90,7 +90,7 @@ sub get {
         # The error code was not found in $errorcodes
         REASON: for my $e ( keys %$messagesof ) {
             # Try to find with each error message defined in $messagesof
-            for my $f ( @{ $messagesof->{ $e } } ) {
+            for my $f ( $messagesof->{ $e }->@* ) {
                 # Find an error reason
                 next unless index($statusmesg, $f) > -1;
                 $reasontext = $e;
@@ -132,7 +132,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2020-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/ExchangeOnline.pm
+++ b/lib/Sisimai/Rhost/ExchangeOnline.pm
@@ -133,7 +133,7 @@ sub get {
     for my $e ( keys %$statuslist ) {
         # Try to compare with each status code as a key
         next unless $statuscode eq $e;
-        for my $f ( @{ $statuslist->{ $e } } ) {
+        for my $f ( $statuslist->{ $e }->@* ) {
             # Try to compare with each string of error messages
             next if index($statusmesg, $f->{'string'}) == -1;
             $reasontext = $f->{'reason'};
@@ -146,9 +146,9 @@ sub get {
     for my $e ( keys %$restatuses ) {
         # Try to compare with each string of delivery status codes
         next unless $statuscode =~ $e;
-        for my $f ( @{ $restatuses->{ $e } } ) {
+        for my $f ( $restatuses->{ $e }->@* ) {
             # Try to compare with each string of error messages
-            for my $g ( @{ $f->{'string'} } ) {
+            for my $g ( $f->{'string'}->@* ) {
                 next if index($statusmesg, $g) == -1;
                 $reasontext = $f->{'reason'};
                 last;
@@ -162,7 +162,7 @@ sub get {
     # D.S.N. included in the error message did not matched with any key in statuslist, restatuses
     for my $e ( keys %$messagesof ) {
         # Try to compare with error messages defined in MessagesOf
-        for my $f ( @{ $messagesof->{ $e } } ) {
+        for my $f ( $messagesof->{ $e }->@* ) {
             next if index($statusmesg, $f) == -1;
             $reasontext = $e;
             last;
@@ -204,7 +204,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/GoDaddy.pm
+++ b/lib/Sisimai/Rhost/GoDaddy.pm
@@ -54,7 +54,7 @@ sub get {
     } else {
         # 553 http://www.spamhaus.org/query/bl?ip=192.0.0.222
         for my $e ( keys %$messagesof ) {
-            for my $f ( @{ $messagesof->{ $e } } ) {
+            for my $f ( $messagesof->{ $e }->@* ) {
                 next if index($statusmesg, $f) == -1;
                 $reasontext = $e;
                 last
@@ -96,7 +96,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2018,2020-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/GoogleApps.pm
+++ b/lib/Sisimai/Rhost/GoogleApps.pm
@@ -108,12 +108,12 @@ sub get {
 
     substr(my $statuscode = $argvs->{'deliverystatus'}, 0, 1, 'X');
     return '' unless exists $statuslist->{ $statuscode };
-    return '' unless scalar @{ $statuslist->{ $statuscode } };
+    return '' unless scalar $statuslist->{ $statuscode }->@*;
 
     my $reasontext = '';
-    for my $e ( @{ $statuslist->{ $statuscode } } ) {
+    for my $e ( $statuslist->{ $statuscode }->@* ) {
         # Try to match
-        next unless grep { rindex($argvs->{'diagnosticcode'}, $_) > -1 } @{ $e->{'string'} };
+        next unless grep { rindex($argvs->{'diagnosticcode'}, $_) > -1 } $e->{'string'}->@*;
         $reasontext = $e->{'reason'};
         last;
     }
@@ -151,7 +151,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP.pm
+++ b/lib/Sisimai/SMTP.pm
@@ -14,7 +14,7 @@ Sisimai::SMTP - SMTP Status Codes related utilities
 =head1 SYNOPSIS
 
     use Sisimai::SMTP;
-    print keys %{ Sisimai::SMTP->command }; # helo, mail, rcpt, data
+    print keys Sisimai::SMTP->command->%*;  # helo, mail, rcpt, data
 
 =head1 DESCRIPTION
 
@@ -26,7 +26,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2016,2020 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2016,2020,2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP/Error.pm
+++ b/lib/Sisimai/SMTP/Error.pm
@@ -97,7 +97,7 @@ sub soft_or_hard {
         # Check all the reasons defined at the above
         SOFT_OR_HARD: for my $e ('hard', 'soft') {
             # Soft or Hard?
-            for my $f ( @{ $softorhard->{ $e } } ) {
+            for my $f ( $softorhard->{ $e }->@* ) {
                 # Hard bounce?
                 next unless $argv1 eq $f;
                 $value = $e;
@@ -154,7 +154,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2018,2020-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP/Transcript.pm
+++ b/lib/Sisimai/SMTP/Transcript.pm
@@ -104,7 +104,7 @@ sub rise {
             $e =~ s/\A<<<[ ]//;
             $cursession->{'response'}->{'reply'}  = $1 if $e =~ /\A([2-5]\d\d)[ ]/;
             $cursession->{'response'}->{'status'} = $1 if $e =~ /\A[245]\d\d[ ]([245][.]\d{1,3}[.]\d{1,3})[ ]/;
-            push(@{ $cursession->{'response'}->{'text'} }, $e);
+            push $cursession->{'response'}->{'text'}->@*, $e;
         }
     }
 


### PR DESCRIPTION
- #446
- For example,
  - `$$neko` => `$neko->$*` (but these codes does not appear at Sisimai)
  - `@{ $neko->{'nyaan'} }` => `$neko->{'nyaan'}->@*`
  - `%{ $neko->{'nyaan'} }` => `$neko->{'nyaan'}->%*`