### PR TITLE
Reduce s///, y/// substitution by using for $v

### DIFF
--- a/lib/Sisimai/Address.pm
+++ b/lib/Sisimai/Address.pm
@@ -164,7 +164,7 @@ sub find {
     #                           email address in the argument
     # @since    v4.22.0
     my $class = shift;
-    my $argv1 = shift // return undef;
+    my $argv1 = shift // return undef; y/\r//d, y/\n//d for $argv1; # Remove CR, NL
     my $addrs = shift // undef;
 
     state $indicators = {
@@ -186,9 +186,6 @@ sub find {
     my $readcursor = 0;
     my $v = $emailtable;   # temporary buffer
     my $p = '';            # current position
-
-    $argv1 =~ y/\r//d if index($argv1, "\r") > -1;  # Remove CR
-    $argv1 =~ y/\n//d if index($argv1, "\n") > -1;  # Remove NL
 
     for my $e ( split('', $argv1) ) {
         # Check each characters
@@ -374,8 +371,7 @@ sub find {
 
         # Remove angle brackets, other brackets, and quotations: []<>{}'` except a domain part is
         # an IP address like neko@[192.0.2.222]
-        $e->{'address'} =~ s/\A[\[<{('`]//;
-        $e->{'address'} =~ s/[.'`>});]\z//;
+        s/\A[\[<{('`]//, s/[.'`>});]\z// for $e->{'address'};
         $e->{'address'} =~ s/\]\z// unless $e->{'address'} =~ /[@]\[[0-9A-Za-z:\.]+\]\z/;
 
         unless( $e->{'address'} =~ /\A["].+["][@]/ ) {
@@ -391,11 +387,7 @@ sub find {
 
         } else {
             # Remove double-quotations, trailing spaces.
-            for my $f ('name', 'comment') {
-                # Remove traliing spaces
-                $e->{ $f } =~ s/\A[ ]//g if index($e->{ $f }, ' ') == 0;
-                $e->{ $f } =~ s/[ ]\z//g if substr($e->{ $f }, -1, 1) eq ' ';
-            }
+            for my $f ('name', 'comment') { s/\A[ ]//g, s/[ ]\z//g for $e->{ $f } }
             $e->{'comment'} = ''   unless $e->{'comment'} =~ /\A[(].+[)]\z/;
             $e->{'name'} =~ y/ //s    unless $e->{'name'} =~ /\A["].+["]\z/;
             $e->{'name'} =~ s/\A["]// unless $e->{'name'} =~ /\A["].+["][@]/;
@@ -617,7 +609,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/DateTime.pm
+++ b/lib/Sisimai/DateTime.pm
@@ -243,9 +243,8 @@ sub parse {
     my $class = shift;
     my $argv1 = shift || return undef;
 
-    my $datestring = $argv1;
-       $datestring =~ s{[,](\d+)}{, $1};  # Thu,13 -> Thu, 13
-       $datestring =~ s{(\d{1,2}),}{$1};    # Apr 29, -> Apr 29
+    # "Apr 29", -> "Apr 29" "Thu,13" -> "Thu, 13"
+    my $datestring = $argv1; s/[,](\d+)/, $1/, s/(\d{1,2}),/$1/ for $datestring;
     my @timetokens = split(' ', $datestring);
     my $parseddate = '';    # [String]  Canonified Date/Time string
     my $afternoon1 = 0;     # [Integer] After noon flag
@@ -258,6 +257,7 @@ sub parse {
         'T' => undef,   # [String]  Time
         'z' => undef,   # [Integer] Timezone offset
     };
+
 
     for my $p ( @timetokens ) {
         # Parse each piece of time
@@ -485,7 +485,7 @@ Sisimai::DateTime - Date and time utilities
 
 =head1 DESCRIPTION
 
-Sisimai::Tie provide methods for dealing date and time.
+Sisimai::DateTime provide methods for dealing date and time.
 
 =head1 CLASS METHODS
 
@@ -521,7 +521,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Fact.pm
+++ b/lib/Sisimai/Fact.pm
@@ -174,8 +174,7 @@ sub rise {
             for my $v ('rhost', 'lhost') {
                 # Check and rewrite each host name
                 $p->{ $v } =  [split('@', $p->{ $v })]->[-1] if index($p->{ $v }, '@') > -1;
-                $p->{ $v } =~ y/[]()//d;    # Remove square brackets and curly brackets from the host variable
-                $p->{ $v } =~ s/\A.+=//;    # Remove string before "="
+                y/[]()//d, s/\A.+=// for $p->{ $v };    # Remove [] and (), and strings before "="
                 chop $p->{ $v } if substr($p->{ $v }, -1, 1) eq "\r";   # Remove CR at the end of the value
 
                 # Check space character in each value and get the first element
@@ -232,8 +231,7 @@ sub rise {
                     # 550-5.7.1 likely unsolicited mail. To reduce the amount of spam sent to Gmail,
                     # 550-5.7.1 this message has been blocked. Please visit
                     # 550 5.7.1 https://support.google.com/mail/answer/188131 for more information.
-                    $p->{'diagnosticcode'} =~ s/$re/ /g;
-                    $p->{'diagnosticcode'} =~ s|<html>.+</html>||i;
+                    s/$re/ /g, s|<html>.+</html>||i for $p->{'diagnosticcode'};
                     $p->{'diagnosticcode'} =  Sisimai::String->sweep($p->{'diagnosticcode'});
                 }
             }
@@ -689,7 +687,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Exim.pm
+++ b/lib/Sisimai/Lhost/Exim.pm
@@ -305,7 +305,7 @@ sub inquire {
         if( defined $mhead->{'x-failed-recipients'} ) {
             # X-Failed-Recipients: kijitora@example.jp
             my @rcptinhead = split(',', $mhead->{'x-failed-recipients'});
-            for my $e ( @rcptinhead ) { $e =~ s/\A[ ]+//; $e =~ s/[ ]+\z// }
+            for my $e ( @rcptinhead ) { s/\A[ ]+//, s/[ ]+\z// for $e }
             $recipients = scalar @rcptinhead;
 
             for my $e ( @rcptinhead ) {
@@ -521,7 +521,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -60,8 +60,7 @@ sub rise {
             if( lc($q) =~ /\A[ \t]*fwd?:[ ]*(.*)\z/ ) {
                 # Delete quoted strings, quote symbols(>)
                 $q = $1;
-                $aftersplit->[2] =~ s/^[>]+[ ]//gm;
-                $aftersplit->[2] =~ s/^[>]$//gm;
+                s/^[>]+[ ]//gm, s/^[>]$//gm for $aftersplit->[2];
             }
             $thing->{'header'}->{'subject'} = $q;
         }
@@ -169,10 +168,8 @@ sub makemap {
     # @return   [Hash]          Structured email header data
     # @since    v4.25.6
     my $class = shift;
-    my $argv0 = shift || return {};
+    my $argv0 = shift || return {}; $$argv0 =~ s/^[>]+[ ]//mg;  # Remove '>' indent symbols
     my $argv1 = shift || 0;
-
-    $$argv0 =~ s/^[>]+[ ]//mg;  # Remove '>' indent symbol of forwarded message
 
     # Select and convert all the headers in $argv0. The following regular expression is based on
     # https://gist.github.com/xtetsuji/b080e1f5551d17242f6415aba8a00239
@@ -181,12 +178,12 @@ sub makemap {
     my $recvheader = [];
 
     $headermaps->{ lc $_ } = $firstpairs->{ $_ } for keys %$firstpairs;
-    for my $e ( values %$headermaps ) { $e =~ s/\n\s+/ /; $e =~ y/\t / /s }
+    for my $e ( values %$headermaps ) { s/\n\s+/ /, y/\t / /s for $e }
 
     if( $$argv0 =~ /^Received:/m ) {
         # Capture values of each Received: header
         $recvheader = [$$argv0 =~ /^Received:[ ]*(.*?)\n(?![\s\t])/gms];
-        for my $e ( @$recvheader ) { $e =~ s/\n\s+/ /; $e =~ y/\n\t / /s }
+        for my $e ( @$recvheader ) { s/\n\s+/ /, y/\n\t / /s for $e }
     }
     $headermaps->{'received'} = $recvheader;
 
@@ -464,7 +461,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Order.pm
+++ b/lib/Sisimai/Order.pm
@@ -10,7 +10,8 @@ sub make {
     # @return        [Array]        Order of MTA modules
     # @since         v4.25.4
     my $class = shift;
-    my $argv0 = shift || return [];
+    my $argv0 = shift || return []; y/_[] / /s, s/\A[ ]+// for $argv0;
+    my @words = split(/[ ]/, lc($argv0), 3);
     my $first = '';
 
     # The following order is decided by the first 2 words of Subject: header
@@ -101,11 +102,6 @@ sub make {
         ],
         'warning' => ['Sisimai::Lhost::Sendmail', 'Sisimai::Lhost::Exim'],
     };
-
-
-    $argv0 =~ y/_[] / /s;
-    $argv0 =~ s/\A[ ]+//;
-    my @words = split(/[ ]/, lc($argv0), 3);
 
     if( rindex($words[0], ':') > 0 ) {
         # Undeliverable: ..., notify: ...
@@ -239,7 +235,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2017,2019-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2017,2019-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC2045.pm
+++ b/lib/Sisimai/RFC2045.pm
@@ -41,9 +41,7 @@ sub decodeH {
 
     while( my $e = shift @$argvs ) {
         # Check and decode each element
-        $e =~ s/\A[ \t]+//g;
-        $e =~ s/[ \t]+\z//g;
-        $e =~ y/"//d;
+        s/\A[ \t]+//g, s/[ \t]+\z//g, y/"//d for $e;
 
         if( __PACKAGE__->is_encoded(\$e) ) {
             # =?utf-8?B?55m954yr44Gr44KD44KT44GT?=
@@ -286,11 +284,11 @@ sub makeflat {
     #   - content-transfer-encoding: quoted-printable  => Content-Transfer-Encoding: quoted-printable
     #   - CHARSET=, BOUNDARY=                          => charset-, boundary=
     #   - message/xdelivery-status                     => message/delivery-status
-    $$argv1 =~ s/[Cc]ontent-[Tt]ype:/Content-Type:/gm;
-    $$argv1 =~ s/[Cc]ontent-[Tt]ransfer-[Ee]ncoding:/Content-Transfer-Encoding:/gm;
-    $$argv1 =~ s/charset=/charset=/igm;
-    $$argv1 =~ s/boundary=/boundary=/igm;
-    $$argv1 =~ s|message/xdelivery-status|message/delivery-status|gm;
+    s/[Cc]ontent-[Tt]ype:/Content-Type:/gm,
+    s/[Cc]ontent-[Tt]ransfer-[Ee]ncoding:/Content-Transfer-Encoding:/gm,
+    s/charset=/charset=/igm,
+    s/boundary=/boundary=/igm,
+    s|message/xdelivery-status|message/delivery-status|gm for $$argv1;
 
     my $iso2022set = qr/charset=["']?(iso-2022-[-a-z0-9]+)['"]?\b/;
     my $multiparts = __PACKAGE__->levelout($argv0, $argv1);
@@ -458,7 +456,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/String.pm
+++ b/lib/Sisimai/String.pm
@@ -52,11 +52,7 @@ sub sweep {
     my $argv1 = shift // return undef;
 
     chomp $argv1;
-    $argv1 =~ y/ //s;
-    $argv1 =~ y/\t//d;
-    $argv1 =~ s/\A //g if index($argv1, ' ') == 0;
-    $argv1 =~ s/ \z//g if substr($argv1, -1, 1) eq ' ';
-    $argv1 =~ s/ [-]{2,}[^ \t].+\z//;
+    y/ //s, y/\t//d, s/\A //g, s/ \z//g, s/ [-]{2,}[^ \t].+\z// for $argv1;
     return $argv1;
 }
 
@@ -82,18 +78,17 @@ sub to_plain {
         # 2. Remove <style>...</style>
         # 3. <a href = 'http://...'>...</a> to " http://... "
         # 4. <a href = 'mailto:...'>...</a> to " Value <mailto:...> "
-        $plain =~ s|<head>.+</head>||gsim;
-        $plain =~ s|<style.+?>.+</style>||gsim;
-        $plain =~ s|<a\s+href\s*=\s*['"](https?://.+?)['"].*?>(.*?)</a>| [$2]($1) |gsim;
-        $plain =~ s|<a\s+href\s*=\s*["']mailto:([^\s]+?)["']>(.*?)</a>| [$2](mailto:$1) |gsim;
-
-        $plain =~ s/<[^<@>]+?>\s*/ /g;  # Delete HTML tags except <neko@example.jp>
-        $plain =~ s/&lt;/</g;           # Convert to left angle brackets
-        $plain =~ s/&gt;/>/g;           # Convert to right angle brackets
-        $plain =~ s/&amp;/&/g;          # Convert to "&"
-        $plain =~ s/&quot;/"/g;         # Convert to '"'
-        $plain =~ s/&apos;/'/g;         # Convert to "'"
-        $plain =~ s/&nbsp;/ /g;         # Convert to ' '
+        s|<head>.+</head>||gsim,
+        s|<style.+?>.+</style>||gsim,
+        s|<a\s+href\s*=\s*['"](https?://.+?)['"].*?>(.*?)</a>| [$2]($1) |gsim,
+        s|<a\s+href\s*=\s*["']mailto:([^\s]+?)["']>(.*?)</a>| [$2](mailto:$1) |gsim,
+        s/<[^<@>]+?>\s*/ /g,    # Delete HTML tags except <neko@example.jp>
+        s/&lt;/</g,             # Convert to left angle brackets
+        s/&gt;/>/g,             # Convert to right angle brackets
+        s/&amp;/&/g,            # Convert to "&"
+        s/&quot;/"/g,           # Convert to '"'
+        s/&apos;/'/g,           # Convert to "'"
+        s/&nbsp;/ /g for $plain;
 
         if( length($$argv1) > length($plain) ) {
             $plain =~ y/ //s;
@@ -218,7 +213,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2019,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2019,2021,2022 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 


### PR DESCRIPTION
# Before
```
$v =~ s/A/B/;
$v =~ s/C/D/;
```

# After
```
s/A/B/, s/C/D/ for $v
```