### PR TITLE
Use v5.26

### DIFF
--- a/lib/Sisimai.pm
+++ b/lib/Sisimai.pm
@@ -1,5 +1,5 @@
 package Sisimai;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use version; our $VERSION = version->declare('v5.0.2'); our $PATCHLV = 0;

--- a/lib/Sisimai/ARF.pm
+++ b/lib/Sisimai/ARF.pm
@@ -1,5 +1,5 @@
 package Sisimai::ARF;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::Lhost;
@@ -366,7 +366,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Address.pm
+++ b/lib/Sisimai/Address.pm
@@ -1,5 +1,5 @@
 package Sisimai::Address;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Class::Accessor::Lite (
@@ -614,7 +614,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/DateTime.pm
+++ b/lib/Sisimai/DateTime.pm
@@ -1,5 +1,5 @@
 package Sisimai::DateTime;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Time::Piece;
@@ -443,7 +443,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Fact.pm
+++ b/lib/Sisimai/Fact.pm
@@ -1,5 +1,5 @@
 package Sisimai::Fact;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::Message;

--- a/lib/Sisimai/Fact/JSON.pm
+++ b/lib/Sisimai/Fact/JSON.pm
@@ -1,5 +1,5 @@
 package Sisimai::Fact::JSON;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use JSON;
@@ -60,7 +60,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Fact/YAML.pm
+++ b/lib/Sisimai/Fact/YAML.pm
@@ -1,5 +1,5 @@
 package Sisimai::Fact::YAML;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -93,7 +93,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost.pm
+++ b/lib/Sisimai/Lhost.pm
@@ -1,5 +1,5 @@
 package Sisimai::Lhost;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::RFC5322;
@@ -96,7 +96,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Activehunter.pm
+++ b/lib/Sisimai/Lhost/Activehunter.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Activehunter;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -111,7 +111,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Amavis.pm
+++ b/lib/Sisimai/Lhost/Amavis.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Amavis;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -197,7 +197,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2019-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2019-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/AmazonSES.pm
+++ b/lib/Sisimai/Lhost/AmazonSES.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::AmazonSES;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/AmazonWorkMail.pm
+++ b/lib/Sisimai/Lhost/AmazonWorkMail.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::AmazonWorkMail;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Aol.pm
+++ b/lib/Sisimai/Lhost/Aol.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Aol;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/ApacheJames.pm
+++ b/lib/Sisimai/Lhost/ApacheJames.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::ApacheJames;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -155,7 +155,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Barracuda.pm
+++ b/lib/Sisimai/Lhost/Barracuda.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Barracuda;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -126,7 +126,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Bigfoot.pm
+++ b/lib/Sisimai/Lhost/Bigfoot.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Bigfoot;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Biglobe.pm
+++ b/lib/Sisimai/Lhost/Biglobe.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Biglobe;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -133,7 +133,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Courier.pm
+++ b/lib/Sisimai/Lhost/Courier.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Courier;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -194,7 +194,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Domino.pm
+++ b/lib/Sisimai/Lhost/Domino.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Domino;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/Lhost/EZweb.pm
+++ b/lib/Sisimai/Lhost/EZweb.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::EZweb;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -203,7 +203,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/EinsUndEins.pm
+++ b/lib/Sisimai/Lhost/EinsUndEins.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::EinsUndEins;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Exchange2003.pm
+++ b/lib/Sisimai/Lhost/Exchange2003.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Exchange2003;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -261,7 +261,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Exchange2007.pm
+++ b/lib/Sisimai/Lhost/Exchange2007.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Exchange2007;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -198,7 +198,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Exim.pm
+++ b/lib/Sisimai/Lhost/Exim.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Exim;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/FML.pm
+++ b/lib/Sisimai/Lhost/FML.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::FML;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -144,7 +144,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Facebook.pm
+++ b/lib/Sisimai/Lhost/Facebook.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Facebook;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/GMX.pm
+++ b/lib/Sisimai/Lhost/GMX.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::GMX;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -152,7 +152,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/GSuite.pm
+++ b/lib/Sisimai/Lhost/GSuite.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::GSuite;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Gmail.pm
+++ b/lib/Sisimai/Lhost/Gmail.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Gmail;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -292,7 +292,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/GoogleGroups.pm
+++ b/lib/Sisimai/Lhost/GoogleGroups.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::GoogleGroups;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/IMailServer.pm
+++ b/lib/Sisimai/Lhost/IMailServer.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::IMailServer;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -136,7 +136,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/InterScanMSS.pm
+++ b/lib/Sisimai/Lhost/InterScanMSS.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::InterScanMSS;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -123,7 +123,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/KDDI.pm
+++ b/lib/Sisimai/Lhost/KDDI.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::KDDI;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -141,7 +141,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MXLogic.pm
+++ b/lib/Sisimai/Lhost/MXLogic.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::MXLogic;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/MailFoundry.pm
+++ b/lib/Sisimai/Lhost/MailFoundry.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::MailFoundry;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -122,7 +122,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MailMarshalSMTP.pm
+++ b/lib/Sisimai/Lhost/MailMarshalSMTP.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::MailMarshalSMTP;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -161,7 +161,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MailRu.pm
+++ b/lib/Sisimai/Lhost/MailRu.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::MailRu;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/McAfee.pm
+++ b/lib/Sisimai/Lhost/McAfee.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::McAfee;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -144,7 +144,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/MessageLabs.pm
+++ b/lib/Sisimai/Lhost/MessageLabs.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::MessageLabs;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/MessagingServer.pm
+++ b/lib/Sisimai/Lhost/MessagingServer.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::MessagingServer;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -193,7 +193,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Notes.pm
+++ b/lib/Sisimai/Lhost/Notes.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Notes;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Encode;
@@ -158,7 +158,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Office365.pm
+++ b/lib/Sisimai/Lhost/Office365.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Office365;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/OpenSMTPD.pm
+++ b/lib/Sisimai/Lhost/OpenSMTPD.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::OpenSMTPD;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -172,7 +172,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Outlook.pm
+++ b/lib/Sisimai/Lhost/Outlook.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Outlook;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Postfix.pm
+++ b/lib/Sisimai/Lhost/Postfix.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Postfix;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/PowerMTA.pm
+++ b/lib/Sisimai/Lhost/PowerMTA.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::PowerMTA;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -153,7 +153,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/ReceivingSES.pm
+++ b/lib/Sisimai/Lhost/ReceivingSES.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::ReceivingSES;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/SendGrid.pm
+++ b/lib/Sisimai/Lhost/SendGrid.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::SendGrid;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Sendmail.pm
+++ b/lib/Sisimai/Lhost/Sendmail.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Sendmail;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/SurfControl.pm
+++ b/lib/Sisimai/Lhost/SurfControl.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::SurfControl;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -141,7 +141,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/V5sendmail.pm
+++ b/lib/Sisimai/Lhost/V5sendmail.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::V5sendmail;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -190,7 +190,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Verizon.pm
+++ b/lib/Sisimai/Lhost/Verizon.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Verizon;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -197,7 +197,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X1.pm
+++ b/lib/Sisimai/Lhost/X1.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::X1;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -113,7 +113,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X2.pm
+++ b/lib/Sisimai/Lhost/X2.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::X2;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -108,7 +108,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X3.pm
+++ b/lib/Sisimai/Lhost/X3.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::X3;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -131,7 +131,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X4.pm
+++ b/lib/Sisimai/Lhost/X4.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::X4;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -307,7 +307,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X5.pm
+++ b/lib/Sisimai/Lhost/X5.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::X5;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -150,7 +150,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/X6.pm
+++ b/lib/Sisimai/Lhost/X6.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::X6;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -128,7 +128,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Yahoo.pm
+++ b/lib/Sisimai/Lhost/Yahoo.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Yahoo;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -137,7 +137,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/Yandex.pm
+++ b/lib/Sisimai/Lhost/Yandex.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Yandex;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/Zoho.pm
+++ b/lib/Sisimai/Lhost/Zoho.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::Zoho;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -147,7 +147,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Lhost/mFILTER.pm
+++ b/lib/Sisimai/Lhost/mFILTER.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::mFILTER;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Lhost/qmail.pm
+++ b/lib/Sisimai/Lhost/qmail.pm
@@ -1,6 +1,6 @@
 package Sisimai::Lhost::qmail;
 use parent 'Sisimai::Lhost';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -274,7 +274,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/MDA.pm
+++ b/lib/Sisimai/MDA.pm
@@ -1,5 +1,5 @@
 package Sisimai::MDA;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -177,7 +177,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Mail.pm
+++ b/lib/Sisimai/Mail.pm
@@ -1,5 +1,5 @@
 package Sisimai::Mail;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Class::Accessor::Lite (
@@ -156,7 +156,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Mail/Maildir.pm
+++ b/lib/Sisimai/Mail/Maildir.pm
@@ -1,5 +1,5 @@
 package Sisimai::Mail::Maildir;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use IO::Dir;
@@ -166,7 +166,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Mail/Mbox.pm
+++ b/lib/Sisimai/Mail/Mbox.pm
@@ -1,5 +1,5 @@
 package Sisimai::Mail::Mbox;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use File::Basename qw(basename dirname);
@@ -153,7 +153,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2019,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2019,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Mail/Memory.pm
+++ b/lib/Sisimai/Mail/Memory.pm
@@ -1,5 +1,5 @@
 package Sisimai::Mail::Memory;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Class::Accessor::Lite (
@@ -123,7 +123,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2018-2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2018-2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Mail/STDIN.pm
+++ b/lib/Sisimai/Mail/STDIN.pm
@@ -1,5 +1,5 @@
 package Sisimai::Mail::STDIN;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use IO::Handle;
@@ -120,7 +120,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Message.pm
+++ b/lib/Sisimai/Message.pm
@@ -1,5 +1,5 @@
 package Sisimai::Message;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::RFC1894;

--- a/lib/Sisimai/Order.pm
+++ b/lib/Sisimai/Order.pm
@@ -1,5 +1,5 @@
 package Sisimai::Order;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::Lhost;
@@ -235,7 +235,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2017,2019-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2017,2019-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC1894.pm
+++ b/lib/Sisimai/RFC1894.pm
@@ -1,5 +1,5 @@
 package Sisimai::RFC1894;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -230,7 +230,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2018-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2018-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC2045.pm
+++ b/lib/Sisimai/RFC2045.pm
@@ -1,5 +1,5 @@
 package Sisimai::RFC2045;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Encode;
@@ -447,7 +447,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC3464.pm
+++ b/lib/Sisimai/RFC3464.pm
@@ -1,5 +1,5 @@
 package Sisimai::RFC3464;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::Lhost;
@@ -436,7 +436,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC3834.pm
+++ b/lib/Sisimai/RFC3834.pm
@@ -175,7 +175,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/RFC3834.pm
+++ b/lib/Sisimai/RFC3834.pm
@@ -1,5 +1,5 @@
 package Sisimai::RFC3834;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/RFC5322.pm
+++ b/lib/Sisimai/RFC5322.pm
@@ -1,5 +1,5 @@
 package Sisimai::RFC5322;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/RFC5965.pm
+++ b/lib/Sisimai/RFC5965.pm
@@ -1,5 +1,5 @@
 package Sisimai::RFC5965;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -50,7 +50,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason.pm
+++ b/lib/Sisimai/Reason.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -525,7 +525,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/AuthFailure.pm
+++ b/lib/Sisimai/Reason/AuthFailure.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::AuthFailure;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/Reason/BadReputation.pm
+++ b/lib/Sisimai/Reason/BadReputation.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::BadReputation;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -94,7 +94,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Blocked.pm
+++ b/lib/Sisimai/Reason/Blocked.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Blocked;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/Reason/ContentError.pm
+++ b/lib/Sisimai/Reason/ContentError.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::ContentError;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -101,7 +101,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2021,2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2021,2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Delivered.pm
+++ b/lib/Sisimai/Reason/Delivered.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Delivered;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -57,7 +57,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/ExceedLimit.pm
+++ b/lib/Sisimai/Reason/ExceedLimit.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::ExceedLimit;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -105,7 +105,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Expired.pm
+++ b/lib/Sisimai/Reason/Expired.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Expired;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Reason/Feedback.pm
+++ b/lib/Sisimai/Reason/Feedback.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Feedback;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -49,7 +49,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Filtered.pm
+++ b/lib/Sisimai/Reason/Filtered.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Filtered;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -124,7 +124,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2018,2020-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2018,2020-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/HasMoved.pm
+++ b/lib/Sisimai/Reason/HasMoved.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::HasMoved;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -84,7 +84,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/HostUnknown.pm
+++ b/lib/Sisimai/Reason/HostUnknown.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::HostUnknown;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;
@@ -120,7 +120,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2018,2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2018,2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/MailboxFull.pm
+++ b/lib/Sisimai/Reason/MailboxFull.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::MailboxFull;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Reason/MailerError.pm
+++ b/lib/Sisimai/Reason/MailerError.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::MailerError;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -91,7 +91,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2017,2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2017,2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/MesgTooBig.pm
+++ b/lib/Sisimai/Reason/MesgTooBig.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::MesgTooBig;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -116,7 +116,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/NetworkError.pm
+++ b/lib/Sisimai/Reason/NetworkError.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::NetworkError;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -97,7 +97,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2018,2020-2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2018,2020-2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/NoRelaying.pm
+++ b/lib/Sisimai/Reason/NoRelaying.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::NoRelaying;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -109,7 +109,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2018,2020-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2018,2020-2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/NotAccept.pm
+++ b/lib/Sisimai/Reason/NotAccept.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::NotAccept;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -97,7 +97,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2020-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2020-2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/NotCompliantRFC.pm
+++ b/lib/Sisimai/Reason/NotCompliantRFC.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::NotCompliantRFC;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Reason/OnHold.pm
+++ b/lib/Sisimai/Reason/OnHold.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::OnHold;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -75,7 +75,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/PolicyViolation.pm
+++ b/lib/Sisimai/Reason/PolicyViolation.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::PolicyViolation;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;
@@ -112,7 +112,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Rejected.pm
+++ b/lib/Sisimai/Reason/Rejected.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Rejected;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Reason/RequirePTR.pm
+++ b/lib/Sisimai/Reason/RequirePTR.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::RequirePTR;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/Reason/SecurityError.pm
+++ b/lib/Sisimai/Reason/SecurityError.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::SecurityError;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/Reason/SpamDetected.pm
+++ b/lib/Sisimai/Reason/SpamDetected.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::SpamDetected;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/Reason/Speeding.pm
+++ b/lib/Sisimai/Reason/Speeding.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Speeding;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -89,7 +89,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Suspend.pm
+++ b/lib/Sisimai/Reason/Suspend.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Suspend;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Reason/SyntaxError.pm
+++ b/lib/Sisimai/Reason/SyntaxError.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::SyntaxError;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -73,7 +73,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/SystemError.pm
+++ b/lib/Sisimai/Reason/SystemError.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::SystemError;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -100,7 +100,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/SystemFull.pm
+++ b/lib/Sisimai/Reason/SystemFull.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::SystemFull;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -78,7 +78,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/TooManyConn.pm
+++ b/lib/Sisimai/Reason/TooManyConn.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::TooManyConn;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -100,7 +100,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Undefined.pm
+++ b/lib/Sisimai/Reason/Undefined.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Undefined;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -49,7 +49,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/UserUnknown.pm
+++ b/lib/Sisimai/Reason/UserUnknown.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::UserUnknown;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;
@@ -235,7 +235,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/Vacation.pm
+++ b/lib/Sisimai/Reason/Vacation.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::Vacation;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -66,7 +66,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2018,2020,2021 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2018,2020,2021,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Reason/VirusDetected.pm
+++ b/lib/Sisimai/Reason/VirusDetected.pm
@@ -1,5 +1,5 @@
 package Sisimai::Reason::VirusDetected;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -101,7 +101,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost.pm
+++ b/lib/Sisimai/Rhost.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -96,7 +96,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2020,2022,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2020,2022-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Cox.pm
+++ b/lib/Sisimai/Rhost/Cox.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::Cox;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -132,7 +132,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2020-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2020-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/FrancePTT.pm
+++ b/lib/Sisimai/Rhost/FrancePTT.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::FrancePTT;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -178,7 +178,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/GoDaddy.pm
+++ b/lib/Sisimai/Rhost/GoDaddy.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::GoDaddy;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -96,7 +96,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2017-2018,2020-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2017-2018,2020-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Google.pm
+++ b/lib/Sisimai/Rhost/Google.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::Google;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 

--- a/lib/Sisimai/Rhost/IUA.pm
+++ b/lib/Sisimai/Rhost/IUA.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::IUA;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -61,7 +61,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2019-2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2019-2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/KDDI.pm
+++ b/lib/Sisimai/Rhost/KDDI.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::KDDI;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -57,7 +57,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2018,2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2018,2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Microsoft.pm
+++ b/lib/Sisimai/Rhost/Microsoft.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::Microsoft;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::SMTP::Status;
@@ -773,7 +773,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Mimecast.pm
+++ b/lib/Sisimai/Rhost/Mimecast.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::Mimecast;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::SMTP::Reply;

--- a/lib/Sisimai/Rhost/NTTDOCOMO.pm
+++ b/lib/Sisimai/Rhost/NTTDOCOMO.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::NTTDOCOMO;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -141,7 +141,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2022,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2022-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Spectrum.pm
+++ b/lib/Sisimai/Rhost/Spectrum.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::Spectrum;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -90,7 +90,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Rhost/Tencent.pm
+++ b/lib/Sisimai/Rhost/Tencent.pm
@@ -1,5 +1,5 @@
 package Sisimai::Rhost::Tencent;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -73,7 +73,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2019,2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2019,2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP.pm
+++ b/lib/Sisimai/SMTP.pm
@@ -1,5 +1,5 @@
 package Sisimai::SMTP;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 1;
@@ -25,7 +25,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2016,2020,2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2016,2020,2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP/Command.pm
+++ b/lib/Sisimai/SMTP/Command.pm
@@ -1,5 +1,5 @@
 package Sisimai::SMTP::Command;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 
@@ -93,7 +93,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2022-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2022-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP/Error.pm
+++ b/lib/Sisimai/SMTP/Error.pm
@@ -1,5 +1,5 @@
 package Sisimai::SMTP::Error;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::SMTP::Reply;
@@ -154,7 +154,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2016-2018,2020-2022 azumakuniyuki, All rights reserved.
+Copyright (C) 2016-2018,2020-2022,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP/Reply.pm
+++ b/lib/Sisimai/SMTP/Reply.pm
@@ -1,5 +1,5 @@
 package Sisimai::SMTP::Reply;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 # http://www.ietf.org/rfc/rfc5321.txt
@@ -218,7 +218,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2015-2016,2018,2020,2021,2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2015-2016,2018,2020,2021,2023,2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/SMTP/Status.pm
+++ b/lib/Sisimai/SMTP/Status.pm
@@ -1,5 +1,5 @@
 package Sisimai::SMTP::Status;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::String;

--- a/lib/Sisimai/SMTP/Transcript.pm
+++ b/lib/Sisimai/SMTP/Transcript.pm
@@ -1,5 +1,5 @@
 package Sisimai::SMTP::Transcript;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Sisimai::SMTP::Reply;
@@ -148,7 +148,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2022-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2022-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/String.pm
+++ b/lib/Sisimai/String.pm
@@ -1,5 +1,5 @@
 package Sisimai::String;
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 use Encode;
@@ -295,7 +295,7 @@ azumakuniyuki
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016,2018,2019,2021-2023 azumakuniyuki, All rights reserved.
+Copyright (C) 2014-2016,2018,2019,2021-2024 azumakuniyuki, All rights reserved.
 
 =head1 LICENSE
 

--- a/lib/Sisimai/Time.pm
+++ b/lib/Sisimai/Time.pm
@@ -1,6 +1,6 @@
 package Sisimai::Time;
 use parent 'Time::Piece';
-use feature ':5.10';
+use v5.26;
 use strict;
 use warnings;
 


### PR DESCRIPTION
- Sisimai 5 requires Perl 5.26 or later
- Declare `use v5.26;`at each file using the postfix dereference
- Replace `use feature ':5.10';` with `use v5.26;`